### PR TITLE
Optional non-announce mode

### DIFF
--- a/mdns-proto/src/config.rs
+++ b/mdns-proto/src/config.rs
@@ -30,7 +30,7 @@ const DEFAULT_RELINQUISHED_RETENTION: core::time::Duration = core::time::Duratio
 pub struct EndpointConfig {
   probe_unique_names: bool,
   answer_questions: bool,
-  announce: bool,
+  re_announce: bool,
   populate_cache: bool,
   trust_advertised_src_as_self: bool,
   relinquished_retention: core::time::Duration,
@@ -38,7 +38,8 @@ pub struct EndpointConfig {
 
 impl EndpointConfig {
   /// Construct with defaults: probe on registration, answer questions,
-  /// announce (unsolicited §8.3 announcements + periodic re-announces), cache
+  /// keep periodically re-announcing at ~80% of the record TTL (so cached
+  /// copies never expire), cache
   /// observations, DO NOT trust advertised-source matching as a self-
   /// loopback signal, and screen a relinquished record set's own echoes for five
   /// seconds (see [`Self::relinquished_retention`]). The default is appropriate
@@ -54,7 +55,7 @@ impl EndpointConfig {
     Self {
       probe_unique_names: true,
       answer_questions: true,
-      announce: true,
+      re_announce: true,
       populate_cache: true,
       trust_advertised_src_as_self: false,
       relinquished_retention: DEFAULT_RELINQUISHED_RETENTION,
@@ -113,30 +114,40 @@ impl EndpointConfig {
     self
   }
 
-  /// Whether to send unsolicited announcements (the RFC 6762 §8.3 startup
-  /// burst and the periodic re-announce), including the §8.1 probe sequence
-  /// that precedes them.
+  /// Whether to keep periodically re-announcing established records at ~80%
+  /// of the record TTL — the RFC 6762 §8.3 periodic refresh that keeps peers'
+  /// cached copies from expiring.
   ///
   /// The default `true` is the conformant responder: probe for the name, then
-  /// announce it so peers learn of the service without asking.  `false`
-  /// switches to a **non-announcing responder**: the service starts established and
-  /// never puts anything on the wire unless an explicit query asks for its
-  /// records.  Useful for battery-sensitive or privacy-conscious devices that
-  /// want to be discoverable when asked but send no background traffic.
+  /// announce it so peers learn of the service without asking, and keep
+  /// re-announcing at ~80% of the record TTL so cached copies never expire.
+  /// `false` switches to a **non-announcing responder**: the §8.1 probe
+  /// sequence and the §8.3 startup burst still run once (so the name is
+  /// verified before it is claimed and peers learn of the service at
+  /// registration), but the periodic re-announce is suppressed, so afterwards
+  /// nothing is put on the wire unless an explicit query asks for the
+  /// service's records.  Useful for battery-sensitive or privacy-conscious
+  /// devices that want to be discoverable when asked but send no background
+  /// traffic.
   #[inline(always)]
-  pub const fn announce(&self) -> bool {
-    self.announce
+  pub const fn re_announce(&self) -> bool {
+    self.re_announce
   }
 
-  /// Set whether to send unsolicited announcements; see [`Self::announce`].
+  /// Set whether to periodically re-announce established records; see
+  /// [`Self::re_announce`].
   ///
-  /// `false` also skips the §8.1 probe sequence: a non-announcing responder claims
-  /// nothing, so there is nothing to probe for.  §9 conflicts are ignored in
-  /// that mode (the name is never claimed, so a peer's claim is not fought
-  /// over) and the registered records are still answered on query.
+  /// `false` suppresses only the post-startup periodic re-announce.  The
+  /// service still performs the RFC 6762 §8.1 probe sequence and the two §8.3
+  /// startup announcements once, then falls silent until queried.  §9
+  /// conflicts are still resolved normally: a conflicting record received
+  /// after establishment reverts the service to probing to re-verify the
+  /// name.  Orthogonal to [`Self::with_probe_unique_names`]: the latter
+  /// controls whether the §8.1 probe runs, the former controls whether the
+  /// name is re-announced after the startup burst.
   #[must_use]
-  pub const fn with_announce(mut self, v: bool) -> Self {
-    self.announce = v;
+  pub const fn with_re_announce(mut self, v: bool) -> Self {
+    self.re_announce = v;
     self
   }
 

--- a/mdns-proto/src/config.rs
+++ b/mdns-proto/src/config.rs
@@ -30,13 +30,15 @@ const DEFAULT_RELINQUISHED_RETENTION: core::time::Duration = core::time::Duratio
 pub struct EndpointConfig {
   probe_unique_names: bool,
   answer_questions: bool,
+  announce: bool,
   populate_cache: bool,
   trust_advertised_src_as_self: bool,
   relinquished_retention: core::time::Duration,
 }
 
 impl EndpointConfig {
-  /// Construct with defaults: probe on registration, answer questions, cache
+  /// Construct with defaults: probe on registration, answer questions,
+  /// announce (unsolicited §8.3 announcements + periodic re-announces), cache
   /// observations, DO NOT trust advertised-source matching as a self-
   /// loopback signal, and screen a relinquished record set's own echoes for five
   /// seconds (see [`Self::relinquished_retention`]). The default is appropriate
@@ -52,6 +54,7 @@ impl EndpointConfig {
     Self {
       probe_unique_names: true,
       answer_questions: true,
+      announce: true,
       populate_cache: true,
       trust_advertised_src_as_self: false,
       relinquished_retention: DEFAULT_RELINQUISHED_RETENTION,
@@ -107,6 +110,33 @@ impl EndpointConfig {
   #[must_use]
   pub const fn with_answer_questions(mut self, v: bool) -> Self {
     self.answer_questions = v;
+    self
+  }
+
+  /// Whether to send unsolicited announcements (the RFC 6762 §8.3 startup
+  /// burst and the periodic re-announce), including the §8.1 probe sequence
+  /// that precedes them.
+  ///
+  /// The default `true` is the conformant responder: probe for the name, then
+  /// announce it so peers learn of the service without asking.  `false`
+  /// switches to a **non-announcing responder**: the service starts established and
+  /// never puts anything on the wire unless an explicit query asks for its
+  /// records.  Useful for battery-sensitive or privacy-conscious devices that
+  /// want to be discoverable when asked but send no background traffic.
+  #[inline(always)]
+  pub const fn announce(&self) -> bool {
+    self.announce
+  }
+
+  /// Set whether to send unsolicited announcements; see [`Self::announce`].
+  ///
+  /// `false` also skips the §8.1 probe sequence: a non-announcing responder claims
+  /// nothing, so there is nothing to probe for.  §9 conflicts are ignored in
+  /// that mode (the name is never claimed, so a peer's claim is not fought
+  /// over) and the registered records are still answered on query.
+  #[must_use]
+  pub const fn with_announce(mut self, v: bool) -> Self {
+    self.announce = v;
     self
   }
 

--- a/mdns-proto/src/endpoint/service.rs
+++ b/mdns-proto/src/endpoint/service.rs
@@ -305,8 +305,10 @@ where
     self.rng.fill_bytes(&mut seed);
     // honor EndpointConfig::probe_unique_names — when disabled the
     // service skips the §8.1 probe sequence and announces immediately.
-    // EndpointConfig::announce(false) additionally switches the service to a
-    // non-announcing responder (established, no announcements at all).
+    // EndpointConfig::re_announce(false) switches the service to a
+    // non-announcing responder: the §8.3 startup burst still runs, but the
+    // periodic re-announce is suppressed, so nothing unsolicited is sent
+    // afterwards.
     let svc = {
       #[allow(unused_mut)]
       let mut s = Service::try_new(
@@ -315,7 +317,7 @@ where
         now,
         seed,
         self.config.probe_unique_names(),
-        self.config.announce(),
+        self.config.re_announce(),
       );
       #[cfg(feature = "stats")]
       s.set_stats(self.stats.clone());

--- a/mdns-proto/src/endpoint/service.rs
+++ b/mdns-proto/src/endpoint/service.rs
@@ -305,6 +305,8 @@ where
     self.rng.fill_bytes(&mut seed);
     // honor EndpointConfig::probe_unique_names — when disabled the
     // service skips the §8.1 probe sequence and announces immediately.
+    // EndpointConfig::announce(false) additionally switches the service to a
+    // non-announcing responder (established, no announcements at all).
     let svc = {
       #[allow(unused_mut)]
       let mut s = Service::try_new(
@@ -313,6 +315,7 @@ where
         now,
         seed,
         self.config.probe_unique_names(),
+        self.config.announce(),
       );
       #[cfg(feature = "stats")]
       s.set_stats(self.stats.clone());

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -978,12 +978,15 @@ cfg_heap! {
   pub struct Service<I, TQ, EV> {
   handle: ServiceHandle,
   state: ServiceState,
-  /// Whether to send unsolicited announcements (RFC 6762 §8.1 probes, §8.3
-  /// startup announcements and periodic re-announces).  When `false` the
-  /// service is a non-announcing responder: it starts in `Established` with no
-  /// lifecycle deadline and only ever emits question responses.  Set via
-  /// `EndpointConfig::with_announce(false)`.
-  announce: bool,
+  /// Whether to keep sending the periodic re-announce.  When `true` (the
+  /// default) the service runs the full RFC 6762 lifecycle: §8.1 probes, §8.3
+  /// startup announcements and the periodic re-announce that keeps peers'
+  /// caches fresh.  When `false` the service is a non-announcing responder: it
+  /// still probes and announces once at startup (RFC 6762 §8.1/§8.3), but the
+  /// periodic re-announce is suppressed, so after the startup burst nothing is
+  /// put on the wire unless an explicit query asks for its records.  Set via
+  /// `EndpointConfig::with_re_announce(false)`.
+  re_announce: bool,
   records: ServiceRecords,
   #[cfg(feature = "stats")]
   stats: Option<std::sync::Arc<hick_trace::stats::Stats>>,
@@ -1236,12 +1239,15 @@ where
   /// `Announcing(0)` and announces without the probe sequence. A later §9
   /// conflict still reverts it to probing to resolve the collision.
   ///
-  /// When `announce` is `false` the service is a non-announcing responder: it starts
-  /// directly in `Established` with **no** lifecycle deadline and never sends
-  /// unsolicited traffic — no probes, no announcements, no periodic
-  /// re-announces — only answers explicit queries for its records (§9
-  /// conflicts are ignored, since a non-announcing responder never claims its
-  /// name).  `announce` takes precedence over `probe`.
+  /// When `re_announce` is `false` the service is a non-announcing responder: it
+  /// runs the startup steps above exactly once — probing (§8.1) if `probe` is
+  /// `true`, then the two §8.3 announcements — and afterwards never sends
+  /// unsolicited traffic. The periodic re-announce is suppressed, so once the
+  /// startup burst is confirmed peers' cached records expire at their TTL and
+  /// the service is only findable by an explicit query.  `re_announce` and
+  /// `probe` are orthogonal: `re_announce` controls the post-startup
+  /// re-announce, `probe` controls whether the name is verified before it is
+  /// claimed.
   #[allow(dead_code)]
   pub(crate) fn try_new(
     handle: ServiceHandle,
@@ -1249,12 +1255,10 @@ where
     now: I,
     rng_seed: [u8; 32],
     probe: bool,
-    announce: bool,
+    re_announce: bool,
   ) -> Self {
     let mut rng = Rng::from_seed(rng_seed);
-    let (state, lifecycle_deadline) = if !announce {
-      (ServiceState::Established, None)
-    } else if probe {
+    let (state, lifecycle_deadline) = if probe {
       (ServiceState::Init, probe_deadline(now, 0, &mut rng))
     } else {
       (ServiceState::Announcing(0), announce_deadline(now, 0))
@@ -1262,7 +1266,7 @@ where
     Self {
       handle,
       state,
-      announce,
+      re_announce,
       records,
       #[cfg(feature = "stats")]
       stats: None,
@@ -2168,7 +2172,17 @@ where
   fn arm_announcement(&mut self, now: I, advance: PhaseAdvance) {
     let ttl_secs = self.records.ttl_secs();
     let base = match self.state {
-      ServiceState::Established => re_announce_deadline(now, ttl_secs),
+      ServiceState::Established => {
+        // A non-announcing responder's §8.3 startup burst is its LAST
+        // unsolicited traffic: peers' copies of the records are left to expire
+        // at the TTL, after which the service is findable only by explicit
+        // query.  No deadline means the lifecycle never fires again.
+        if !self.re_announce {
+          self.lifecycle_deadline = None;
+          return;
+        }
+        re_announce_deadline(now, ttl_secs)
+      }
       ServiceState::Announcing(_) => match advance {
         PhaseAdvance::Partial => {
           partial_announce_deadline(now, self.partial_announce_streak, ttl_secs)
@@ -3255,19 +3269,6 @@ where
         ServiceState::Announcing(_) | ServiceState::Established,
         ServiceEvent::ProbeConflict(pc),
       ) => {
-        // A non-announcing responder never claims its name (no probes, no
-        // announcements), so a peer's conflicting claim is not fought over —
-        // stay established and keep answering queries. The name is the
-        // caller's immutable identity (e.g. a node id), so a collision is
-        // effectively impossible anyway.
-        if !self.announce {
-          trace!(
-            target: "mdns_proto::service",
-            handle = self.handle.raw(),
-            "service: §9 conflict ignored — non-announcing responder claims nothing"
-          );
-          return;
-        }
         // RFC 6762 §9 post-establishment conflict — NOT the §8.2
         // lexicographic probe tiebreak. A §9 conflict is the same name/type/
         // class with DIFFERENT rdata; an identical record is consistent and

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -978,6 +978,12 @@ cfg_heap! {
   pub struct Service<I, TQ, EV> {
   handle: ServiceHandle,
   state: ServiceState,
+  /// Whether to send unsolicited announcements (RFC 6762 §8.1 probes, §8.3
+  /// startup announcements and periodic re-announces).  When `false` the
+  /// service is a non-announcing responder: it starts in `Established` with no
+  /// lifecycle deadline and only ever emits question responses.  Set via
+  /// `EndpointConfig::with_announce(false)`.
+  announce: bool,
   records: ServiceRecords,
   #[cfg(feature = "stats")]
   stats: Option<std::sync::Arc<hick_trace::stats::Stats>>,
@@ -1229,6 +1235,13 @@ where
   /// skipping probing in that case), so the service starts directly in
   /// `Announcing(0)` and announces without the probe sequence. A later §9
   /// conflict still reverts it to probing to resolve the collision.
+  ///
+  /// When `announce` is `false` the service is a non-announcing responder: it starts
+  /// directly in `Established` with **no** lifecycle deadline and never sends
+  /// unsolicited traffic — no probes, no announcements, no periodic
+  /// re-announces — only answers explicit queries for its records (§9
+  /// conflicts are ignored, since a non-announcing responder never claims its
+  /// name).  `announce` takes precedence over `probe`.
   #[allow(dead_code)]
   pub(crate) fn try_new(
     handle: ServiceHandle,
@@ -1236,9 +1249,12 @@ where
     now: I,
     rng_seed: [u8; 32],
     probe: bool,
+    announce: bool,
   ) -> Self {
     let mut rng = Rng::from_seed(rng_seed);
-    let (state, lifecycle_deadline) = if probe {
+    let (state, lifecycle_deadline) = if !announce {
+      (ServiceState::Established, None)
+    } else if probe {
       (ServiceState::Init, probe_deadline(now, 0, &mut rng))
     } else {
       (ServiceState::Announcing(0), announce_deadline(now, 0))
@@ -1246,6 +1262,7 @@ where
     Self {
       handle,
       state,
+      announce,
       records,
       #[cfg(feature = "stats")]
       stats: None,
@@ -3238,6 +3255,19 @@ where
         ServiceState::Announcing(_) | ServiceState::Established,
         ServiceEvent::ProbeConflict(pc),
       ) => {
+        // A non-announcing responder never claims its name (no probes, no
+        // announcements), so a peer's conflicting claim is not fought over —
+        // stay established and keep answering queries. The name is the
+        // caller's immutable identity (e.g. a node id), so a collision is
+        // effectively impossible anyway.
+        if !self.announce {
+          trace!(
+            target: "mdns_proto::service",
+            handle = self.handle.raw(),
+            "service: §9 conflict ignored — non-announcing responder claims nothing"
+          );
+          return;
+        }
         // RFC 6762 §9 post-establishment conflict — NOT the §8.2
         // lexicographic probe tiebreak. A §9 conflict is the same name/type/
         // class with DIFFERENT rdata; an identical record is consistent and

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -74,6 +74,7 @@ fn non_probing_service_announces_without_probing() {
       FakeInstant::zero(),
       [0u8; 32],
       false, // do not probe
+      true, // announce
     );
   assert!(
     matches!(svc.state(), ServiceState::Announcing(_)),
@@ -109,13 +110,72 @@ fn non_probing_service_announces_without_probing() {
   );
 }
 
+/// A non-announcing responder (`EndpointConfig::with_announce(false)`) starts
+/// established and never emits unsolicited traffic — no §8.1 probes, no §8.3
+/// announcements, no periodic re-announces — but still answers explicit
+/// queries for its records.
+#[test]
+fn non_announcing_responder_answers_questions_only() {
+  use crate::{event::ServiceQuestion, wire::QuestionRef};
+  let records = make_records(120);
+  let mut svc: Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>> =
+    Service::try_new(
+      ServiceHandle::from_raw(0),
+      records,
+      FakeInstant::zero(),
+      [0u8; 32],
+      true, // probe — irrelevant, announce wins
+      false, // announce
+    );
+  assert_eq!(
+    svc.state(),
+    ServiceState::Established,
+    "non-announcing service must start established"
+  );
+
+  // Many ticks with a successful-delivery driver: no lifecycle transmit
+  // (probe or announcement) may ever come out.
+  let mut buf = std::vec![0u8; 4096];
+  let mut now = FakeInstant::zero();
+  for _ in 0..100 {
+    now = now.advance(500);
+    svc.handle_timeout(now).unwrap();
+    assert!(
+      svc.poll_transmit(now, &mut buf).unwrap().is_none(),
+      "non-announcing service must never emit unsolicited traffic"
+    );
+  }
+
+  // An explicit query IS answered (after the 20–120 ms jitter window).
+  let mut qbuf: std::vec::Vec<u8> = std::vec::Vec::new();
+  for label in "_ipp._tcp.local.".trim_end_matches('.').split('.') {
+    qbuf.push(label.len() as u8);
+    qbuf.extend_from_slice(label.as_bytes());
+  }
+  qbuf.push(0u8);
+  qbuf.extend_from_slice(&12u16.to_be_bytes()); // QTYPE PTR
+  qbuf.extend_from_slice(&1u16.to_be_bytes()); // QCLASS IN
+  let (qref, _) = QuestionRef::try_parse(&qbuf, 0).unwrap();
+  let src: core::net::SocketAddr = "192.0.2.7:5353".parse().unwrap();
+  svc.handle_event(
+    ServiceEvent::Question(ServiceQuestion::new(qref, src, 0)),
+    now,
+  );
+  now = now.advance(200);
+  svc.handle_timeout(now).unwrap();
+  assert!(
+    svc.poll_transmit(now, &mut buf).unwrap().is_some(),
+    "non-announcing service must answer explicit queries"
+  );
+}
+
 /// Build a Service in Init state with last_now = FakeInstant::zero().
 fn make_service(
   ttl_secs: u32,
 ) -> Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>> {
   let handle = ServiceHandle::from_raw(0);
   let records = make_records(ttl_secs);
-  Service::try_new(handle, records, FakeInstant::zero(), [0u8; 32], true)
+  Service::try_new(handle, records, FakeInstant::zero(), [0u8; 32], true, true)
 }
 
 /// One record of a peer's §8.2 proposal, as it goes on the wire.
@@ -861,7 +921,7 @@ fn advertised_host_addrs_are_the_emitted_subset_not_configured() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   assert!(
     svc.advertised_a_addrs().is_empty(),
     "nothing advertised before any confirmed send"
@@ -2497,7 +2557,7 @@ fn host_conflict_for_identical_link_local_address_is_suppressed() {
         FakeInstant::zero(),
         [0u8; 32],
         true,
-      );
+      true);
     svc.handle_timeout(FakeInstant::zero()).unwrap();
     svc
   };
@@ -2567,7 +2627,7 @@ fn failed_conflict_rename_clears_stale_transmit_state() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   // A probe on the wire first, then a conflicting RESPONSE — §8.1's rename is
   // the one that can FAIL here. A §8.2 tiebreak loss now defers and keeps the
   // name, so it never attempts the suffix at all.
@@ -2630,7 +2690,7 @@ fn a_terminal_service_still_surfaces_a_host_conflict() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   let t0 = probe_once(&mut svc, FakeInstant::zero());
   deliver_losing_srv_conflict(&mut svc, t0, ConflictOrigin::AuthoritativeResponse);
   svc.handle_timeout(t0.advance(500)).unwrap();
@@ -4909,7 +4969,7 @@ fn tiebreak_records_that_flatten_alike_are_not_a_tie() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   let t0 = FakeInstant::zero();
   svc.handle_timeout(t0).unwrap(); // Init → Probing
   let original = svc.name().as_str().to_owned();
@@ -6130,7 +6190,7 @@ fn subtype_ptr_advertised_in_response() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   let now = drive_to_established(&mut svc);
 
   // A question response carries the subtype PTR at positive TTL.
@@ -6237,7 +6297,7 @@ fn legacy_subtype_browse_gets_unicast_reply_with_subtype_ptr() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   let now = drive_to_established(&mut svc);
 
   let mut qbuf: std::vec::Vec<u8> = std::vec::Vec::new();
@@ -10605,7 +10665,7 @@ fn a_record_outside_the_probes_qtype_is_still_proposed() {
         FakeInstant::zero(),
         [0u8; 32],
         true,
-      );
+      true);
     let t0 = FakeInstant::zero();
     svc.handle_timeout(t0).unwrap();
 
@@ -11044,7 +11104,7 @@ fn a_conforming_twins_nsec_is_not_a_conflict_when_the_host_is_the_instance_name(
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    );
+    true);
   let start = probe_once(&mut svc, FakeInstant::zero());
 
   let nsec_record = |types: &[u16], buf: &mut [u8; 512]| -> std::vec::Vec<u8> {
@@ -11561,7 +11621,7 @@ fn make_service_with(
     FakeInstant::zero(),
     [0u8; 32],
     true,
-  )
+  true)
 }
 
 /// RFC 6762 §9 makes a conflict "the same name, **rrtype** and rrclass, but

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -74,7 +74,7 @@ fn non_probing_service_announces_without_probing() {
       FakeInstant::zero(),
       [0u8; 32],
       false, // do not probe
-      true, // announce
+      true,  // re-announce
     );
   assert!(
     matches!(svc.state(), ServiceState::Announcing(_)),
@@ -110,13 +110,17 @@ fn non_probing_service_announces_without_probing() {
   );
 }
 
-/// A non-announcing responder (`EndpointConfig::with_announce(false)`) starts
-/// established and never emits unsolicited traffic — no §8.1 probes, no §8.3
-/// announcements, no periodic re-announces — but still answers explicit
-/// queries for its records.
+/// A non-announcing responder (`EndpointConfig::with_re_announce(false)`) runs
+/// the RFC 6762 §8.1/§8.3 startup sequence once — probing so the name is
+/// verified, then the two §8.3 announcements — and never sends the periodic
+/// re-announce.  Afterwards it is silent until an explicit query asks for its
+/// records, and a §9 conflict still reverts it to probing.
 #[test]
 fn non_announcing_responder_answers_questions_only() {
-  use crate::{event::ServiceQuestion, wire::QuestionRef};
+  use crate::{
+    event::ServiceQuestion,
+    wire::{MessageReader, QuestionRef, ResourceType},
+  };
   let records = make_records(120);
   let mut svc: Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>> =
     Service::try_new(
@@ -124,29 +128,77 @@ fn non_announcing_responder_answers_questions_only() {
       records,
       FakeInstant::zero(),
       [0u8; 32],
-      true, // probe — irrelevant, announce wins
-      false, // announce
+      true,  // probe
+      false, // re-announce
     );
+
+  // The startup is the NORMAL conformant lifecycle: probe (§8.1), then the two
+  // §8.3 announcements, ending in Established with the caller's usual signals.
+  let mut buf = std::vec![0u8; 4096];
+  let mut now = FakeInstant::zero();
+  let mut saw_probe = false;
+  let mut saw_announcement = false;
+  for _ in 0..30 {
+    now = now.advance(500);
+    svc.handle_timeout(now).unwrap();
+    while let Ok(Some(tx)) = svc.poll_transmit(now, &mut buf) {
+      let reader = MessageReader::try_parse(buf.get(..tx.size()).unwrap()).unwrap();
+      if reader.header().flags().is_response() {
+        saw_announcement = true;
+      } else {
+        saw_probe = true;
+      }
+      svc.note_delivery(now, TransmitDelivery::ALL);
+    }
+    if svc.state() == ServiceState::Established {
+      break;
+    }
+  }
+  assert!(
+    saw_probe,
+    "non-announcing responder must still probe (§8.1) — the name is verified before it is claimed"
+  );
+  assert!(
+    saw_announcement,
+    "non-announcing responder must still announce at startup (§8.3)"
+  );
   assert_eq!(
     svc.state(),
     ServiceState::Established,
-    "non-announcing service must start established"
+    "non-announcing responder must reach Established via the normal lifecycle"
+  );
+  assert!(
+    svc.has_fully_announced().get(),
+    "the startup burst must fully announce the records"
+  );
+  let mut established = false;
+  while let Some(u) = svc.poll() {
+    established |= matches!(u, ServiceUpdate::Established);
+  }
+  assert!(
+    established,
+    "the Established update must be queued by the normal Announcing → Established transition"
   );
 
-  // Many ticks with a successful-delivery driver: no lifecycle transmit
-  // (probe or announcement) may ever come out.
-  let mut buf = std::vec![0u8; 4096];
-  let mut now = FakeInstant::zero();
-  for _ in 0..100 {
+  // Established arms NO periodic re-announce, and none ever fires — even far
+  // past the ~96 s refresh interval (0.8 × TTL 120) the service stays silent.
+  assert_eq!(
+    svc.lifecycle_deadline, None,
+    "a non-announcing responder must arm no periodic re-announce"
+  );
+  for _ in 0..300 {
     now = now.advance(500);
     svc.handle_timeout(now).unwrap();
     assert!(
       svc.poll_transmit(now, &mut buf).unwrap().is_none(),
-      "non-announcing service must never emit unsolicited traffic"
+      "non-announcing responder must never emit unsolicited traffic after startup"
     );
   }
 
-  // An explicit query IS answered (after the 20–120 ms jitter window).
+  // An explicit query IS answered, with the full record set.  The unique
+  // records carry the cache-flush bit — the name was verified by the §8.1
+  // probe, so this is a legitimate assertion of uniqueness, not an
+  // unverified claim.
   let mut qbuf: std::vec::Vec<u8> = std::vec::Vec::new();
   for label in "_ipp._tcp.local.".trim_end_matches('.').split('.') {
     qbuf.push(label.len() as u8);
@@ -163,9 +215,42 @@ fn non_announcing_responder_answers_questions_only() {
   );
   now = now.advance(200);
   svc.handle_timeout(now).unwrap();
-  assert!(
-    svc.poll_transmit(now, &mut buf).unwrap().is_some(),
-    "non-announcing service must answer explicit queries"
+  let tx = svc
+    .poll_transmit(now, &mut buf)
+    .unwrap()
+    .expect("non-announcing service must answer explicit queries");
+  let reader = MessageReader::try_parse(buf.get(..tx.size()).unwrap()).unwrap();
+  let mut answered = false;
+  for rr in reader.answers() {
+    let rr = rr.unwrap();
+    match rr.rtype() {
+      ResourceType::Srv | ResourceType::Txt | ResourceType::A | ResourceType::AAAA => {
+        assert!(
+          rr.cache_flush(),
+          "{:?} answer must carry the cache-flush bit — the name was verified by §8.1",
+          rr.rtype()
+        );
+      }
+      ResourceType::Ptr => {
+        assert!(
+          !rr.cache_flush(),
+          "PTR is a shared record — it must NOT carry the cache-flush bit"
+        );
+      }
+      _ => {}
+    }
+    answered = true;
+  }
+  assert!(answered, "the query response must carry records");
+  svc.note_delivery(now, TransmitDelivery::ALL);
+
+  // §9 conflicts are NOT ignored: a conflicting response still reverts the
+  // service to probing to re-verify the name.
+  deliver_losing_srv_conflict(&mut svc, now, ConflictOrigin::AuthoritativeResponse);
+  assert_eq!(
+    svc.state(),
+    ServiceState::Init,
+    "a §9 conflict must revert a non-announcing responder to re-probing"
   );
 }
 
@@ -921,7 +1006,8 @@ fn advertised_host_addrs_are_the_emitted_subset_not_configured() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   assert!(
     svc.advertised_a_addrs().is_empty(),
     "nothing advertised before any confirmed send"
@@ -2557,7 +2643,8 @@ fn host_conflict_for_identical_link_local_address_is_suppressed() {
         FakeInstant::zero(),
         [0u8; 32],
         true,
-      true);
+        true,
+      );
     svc.handle_timeout(FakeInstant::zero()).unwrap();
     svc
   };
@@ -2627,7 +2714,8 @@ fn failed_conflict_rename_clears_stale_transmit_state() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   // A probe on the wire first, then a conflicting RESPONSE — §8.1's rename is
   // the one that can FAIL here. A §8.2 tiebreak loss now defers and keeps the
   // name, so it never attempts the suffix at all.
@@ -2690,7 +2778,8 @@ fn a_terminal_service_still_surfaces_a_host_conflict() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   let t0 = probe_once(&mut svc, FakeInstant::zero());
   deliver_losing_srv_conflict(&mut svc, t0, ConflictOrigin::AuthoritativeResponse);
   svc.handle_timeout(t0.advance(500)).unwrap();
@@ -4969,7 +5058,8 @@ fn tiebreak_records_that_flatten_alike_are_not_a_tie() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   let t0 = FakeInstant::zero();
   svc.handle_timeout(t0).unwrap(); // Init → Probing
   let original = svc.name().as_str().to_owned();
@@ -6190,7 +6280,8 @@ fn subtype_ptr_advertised_in_response() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   let now = drive_to_established(&mut svc);
 
   // A question response carries the subtype PTR at positive TTL.
@@ -6297,7 +6388,8 @@ fn legacy_subtype_browse_gets_unicast_reply_with_subtype_ptr() {
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   let now = drive_to_established(&mut svc);
 
   let mut qbuf: std::vec::Vec<u8> = std::vec::Vec::new();
@@ -10665,7 +10757,8 @@ fn a_record_outside_the_probes_qtype_is_still_proposed() {
         FakeInstant::zero(),
         [0u8; 32],
         true,
-      true);
+        true,
+      );
     let t0 = FakeInstant::zero();
     svc.handle_timeout(t0).unwrap();
 
@@ -11104,7 +11197,8 @@ fn a_conforming_twins_nsec_is_not_a_conflict_when_the_host_is_the_instance_name(
       FakeInstant::zero(),
       [0u8; 32],
       true,
-    true);
+      true,
+    );
   let start = probe_once(&mut svc, FakeInstant::zero());
 
   let nsec_record = |types: &[u16], buf: &mut [u8; 512]| -> std::vec::Vec<u8> {
@@ -11621,7 +11715,8 @@ fn make_service_with(
     FakeInstant::zero(),
     [0u8; 32],
     true,
-  true)
+    true,
+  )
 }
 
 /// RFC 6762 §9 makes a conflict "the same name, **rrtype** and rrclass, but


### PR DESCRIPTION
This allows to reduce the mDNS traffic to a minimum and finding non-announce peers is only possible via an explicit query.