### PR TITLE
fix(mdns-proto): apply RFC 6762 §8.1's conflict flood limit to re-probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@
   endpoint-wide, which is still not host-wide, because a second `Endpoint`, or a
   second process, on the same machine is beyond anything this library can
   observe.
+- `mdns-proto`: the doc on `CONFLICT_REPROBE_MIN_INTERVAL` no longer claims that
+  a hostile peer "cannot prevent the service from ever (re)establishing". It
+  can. A peer that answers each first probe with conflicting authoritative data
+  for the current renamed instance restarts the sequence before probes two and
+  three go out, and those conflicts land pre-authoritatively, where §9's
+  interval does not apply — so a peer willing to conflict with every name
+  attempted keeps the service out of `Announcing` indefinitely. What the two
+  limits bound between them is the rate, not progress: once §8.1's floor is
+  latched the loop turns about once per five seconds. The denial of service
+  itself is inherent to a same-link name adversary; only the claim was wrong.
 
 ## A relinquished record set can no longer retire its own replacement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # UNRELEASED
 
+## A persistent same-name peer can no longer drive an unthrottled rename loop
+
+- `mdns-proto`: a `Service` now applies RFC 6762 §8.1's flood limit — "if
+  fifteen conflicts occur within any ten-second period, then the host MUST wait
+  at least five seconds before each successive additional probe attempt". Every
+  conflict-driven probe sequence was scheduled with §8.1's ordinary 0-250 ms
+  *startup* delay however many renames had already happened, so a peer that
+  defends each name the service renames itself to — hostile, or merely a
+  misconfigured twin — drove an unbounded rename → announce → probe loop, each
+  turn putting packets on the link. The count is of CONFLICTS, which is what
+  §8.1 counts, so it deliberately spans renames and probe restarts: resetting it
+  on a rename would reset it on the very event being throttled. It is kept in a
+  fixed ring of fifteen instants — the condition is exactly "is the
+  fifteenth-most-recent conflict within ten seconds of now" — so nothing is
+  allocated. Once in force the floor applies to *each* successive attempt and is
+  released only by the flood stopping: a whole ten-second window with no
+  conflict at all. Re-deriving it per probe instead would come off two turns
+  later and hand the flood its speed back, because five-second spacing is itself
+  too slow to keep fifteen conflicts inside ten seconds. The floor is applied
+  where every restarted sequence gets its start time, so it covers §9's
+  revert-to-probing, §8.2's one-second deferral and §8.1's rename alike, and
+  raises each only when the limit is in force. §9's own
+  `CONFLICT_REPROBE_MIN_INTERVAL` is a different rule over a different quantity
+  and is unchanged: it still bounds how often an established name may be sent
+  back to probing at all, and a conflict it drops re-probes nothing and is
+  counted by neither rule.
+
 ## A relinquished record set can no longer retire its own replacement
 
 - `mdns-proto`: `Endpoint` screens every conflict candidate against the record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # UNRELEASED
 
-## A persistent same-name peer can no longer drive an unthrottled rename loop
+## A persistent same-name peer no longer drives one record set's rename loop unthrottled
 
 - `mdns-proto`: a `Service` now applies RFC 6762 §8.1's flood limit — "if
   fifteen conflicts occur within any ten-second period, then the host MUST wait
-  at least five seconds before each successive additional probe attempt". Every
-  conflict-driven probe sequence was scheduled with §8.1's ordinary 0-250 ms
-  *startup* delay however many renames had already happened, so a peer that
-  defends each name the service renames itself to — hostile, or merely a
-  misconfigured twin — drove an unbounded rename → announce → probe loop, each
-  turn putting packets on the link. The count is of CONFLICTS, which is what
+  at least five seconds before each successive additional probe attempt" — **to
+  its own record set**. Every conflict-driven probe sequence was scheduled with
+  §8.1's ordinary 0-250 ms *startup* delay however many renames had already
+  happened, so a peer that defends each name the service renames itself to —
+  hostile, or merely a misconfigured twin — drove an unbounded rename → announce
+  → probe loop, each turn putting packets on the link. The count is of CONFLICTS, which is what
   §8.1 counts, so it deliberately spans renames and probe restarts: resetting it
   on a rename would reset it on the very event being throttled. It is kept in a
   fixed ring of fifteen instants — the condition is exactly "is the
@@ -26,6 +26,23 @@
   and is unchanged: it still bounds how often an established name may be sent
   back to probing at all, and a conflict it drops re-probes nothing and is
   counted by neither rule.
+- `mdns-proto`: **the scope of that limit is per record set, and §8.1 states its
+  obligation on the host.** The counter lives on one `Service`, so what it bounds
+  is one record set's restarts, and three ways past it are known and remain open.
+  Conflicts are not aggregated across record sets: fifteen entries spaced `d`
+  apart span `14·d`, so a service whose restarts are slower than 10/14 ≈ 0.714 s
+  never latches at all, and N services contending at that rate put N × 1.4
+  restarts per second on the link between them. A freshly registered service
+  starts with an empty ring and is not slowed by another service's backoff
+  already being in force. And the history dies with the `Service`: a
+  `HostConflict` is terminal and is surfaced for the caller to intervene, and the
+  usual intervention — unregister, then re-register under a new host name — hands
+  the replacement a clean ring, so a loop closed through the driver layer evades
+  even the per-record-set latch. Aggregating the ring at the `Endpoint` and
+  sharing only the verdict is tracked as **#140**; that will make the limit
+  endpoint-wide, which is still not host-wide, because a second `Endpoint`, or a
+  second process, on the same machine is beyond anything this library can
+  observe.
 
 ## A relinquished record set can no longer retire its own replacement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,25 @@
   limits bound between them is the rate, not progress: once §8.1's floor is
   latched the loop turns about once per five seconds. The denial of service
   itself is inherent to a same-link name adversary; only the claim was wrong.
+- `mdns-proto`: when the flood limit is in force and the clock cannot represent
+  `now + 5 s`, a conflict-driven restart now arms **no deadline at all** instead
+  of falling back to the caller's shorter one. `Instant::checked_add_duration`
+  returns `Option`, so a bounded clock is part of the contract this crate
+  publishes rather than a pathological case — a wrapping millisecond counter is
+  an ordinary choice for a bare-metal driver, which is also where an unthrottled
+  flood costs the most. The old fallback discarded the MUST at exactly the moment
+  the limiter existed to hold a probe back, scheduling one as little as 250 ms
+  out on the rename and §9 paths and a second out on §8.2; and when the caller's
+  own deadline overflowed too it stored `None` and tripped the regress
+  invariant, turning a peer's proposal into a debug-build panic reachable
+  straight from network input. Saturating to the furthest representable instant
+  is not the fix either: at the end of the clock that instant can be `now`, which
+  schedules the probe immediately. Arming nothing is the only value that is never
+  sooner than an unrepresentable floor. The `Init` re-schedule applies the same
+  floor, so it re-evaluates each timeout rather than fabricating a fresh
+  0-250 ms delay for a sequence the limit is holding, and the regress invariant
+  now reads "armed, or the clock cannot express the wait §8.1 owes". Services
+  whose limit is not in force are untouched, overflow and all.
 
 ## A relinquished record set can no longer retire its own replacement
 

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -80,8 +80,24 @@ cfg_heap! {
 
   /// minimum interval between conflict-driven re-probes of an
   /// Established/Announcing service (RFC 6762 §9 conflict rate-limiting). A
-  /// conflict flood cannot reset us to Probing faster than this, so a hostile
-  /// peer cannot prevent the service from ever (re)establishing.
+  /// conflict flood cannot reset us to Probing more than once per interval.
+  ///
+  /// # That is a RATE bound, and it is not a guarantee of progress
+  ///
+  /// It does not follow, and this comment used to say it did, that the service
+  /// eventually (re)establishes. A peer that watches for each first probe and
+  /// answers it immediately with conflicting authoritative data for the CURRENT
+  /// renamed instance restarts the sequence before probes two and three ever go
+  /// out. Those conflicts arrive PRE-AUTHORITATIVELY — §8.1's rename and §8.2's
+  /// deferral adjudicate them, and this interval guards neither; it guards the
+  /// §9 established-state revert only. So a peer willing to conflict with every
+  /// name this service attempts keeps it out of `Announcing` indefinitely, and
+  /// no responder-side rule can stop that: denying a name on the local link is
+  /// something a same-link adversary can simply do.
+  ///
+  /// What the two limits bound between them is the COST of being denied. Once
+  /// §8.1's floor is latched, the loop turns roughly once per five seconds
+  /// instead of several times a second.
   ///
   /// This is NOT the §8.1 flood limit below it, and both are live at once. This
   /// one bounds how often an ESTABLISHED name may be sent back to probing at

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -2840,27 +2840,17 @@ where
     // caller's schedule is a FLOOR away from, never a ceiling on, what it asked
     // for — §8.2's one-second deferral is still owed in full, it is simply not
     // enough on its own once the limit is in force.
-    self.lifecycle_deadline = if self.note_conflict(now) {
-      match (deadline, now.checked_add_duration(CONFLICT_BACKOFF_MIN_WAIT)) {
-        (Some(d), Some(floor)) => Some(d.max(floor)),
-        // The caller's own arithmetic overflowed the clock. The floor is still a
-        // legal start for the sequence, and conjunct 8 below says a regress that
-        // armed nothing would strand the service.
-        (None, floor) => floor,
-        // …and the other way round: the floor overflowed where the caller's
-        // deadline did not, so keep the deadline rather than drop the service
-        // off the clock over a limit that is about slowing it down.
-        (Some(d), None) => Some(d),
-      }
-    } else {
-      deadline
-    };
+    self.note_conflict(now);
+    self.lifecycle_deadline = self.apply_backoff_floor(now, deadline);
     #[cfg(debug_assertions)]
-    self.assert_generation_replaced();
+    self.assert_generation_replaced(now);
   }
 
-  /// Fold one conflict into RFC 6762 §8.1's flood test FOR THIS RECORD SET, and
-  /// report whether its five-second floor is now in force.
+  /// Fold one conflict into RFC 6762 §8.1's flood test FOR THIS RECORD SET,
+  /// engaging `conflict_backoff` if this one completes the condition.
+  ///
+  /// Records; it does not schedule. [`Service::apply_backoff_floor`] reads the
+  /// latch and is what turns it into a deadline.
   ///
   /// > If fifteen conflicts occur within any ten-second period, then the host
   /// > MUST wait at least five seconds before each successive additional probe
@@ -2881,7 +2871,7 @@ where
   /// The clock is assumed monotonic, as [`crate::Instant`] requires. Where it is
   /// not, both tests below fail CLOSED: a `now` that ran backwards neither
   /// releases the latch nor engages it.
-  fn note_conflict(&mut self, now: I) -> bool {
+  fn note_conflict(&mut self, now: I) {
     // The flood has stopped if a whole window has gone by with no conflict at
     // all. Tested BEFORE this conflict is folded in, and against the previous
     // newest — so a fresh burst from a peer that had fallen quiet starts over
@@ -2912,7 +2902,52 @@ where
     {
       self.conflict_backoff = true;
     }
-    self.conflict_backoff
+  }
+
+  /// Raise a restarted sequence's start time to RFC 6762 §8.1's five-second
+  /// floor when this record set's flood limit is in force — and arm NOTHING when
+  /// the clock cannot represent that floor.
+  ///
+  /// # Failing closed is the whole of the overflow rule
+  ///
+  /// [`crate::Instant`] returns `Option` from `checked_add_duration`, so a
+  /// BOUNDED clock is part of the contract this crate publishes, not a
+  /// pathological case — a wrapping millisecond counter is an ordinary choice
+  /// for a bare-metal driver, and a bare-metal driver is where an unthrottled
+  /// flood costs the most. When `now + CONFLICT_BACKOFF_MIN_WAIT` does not exist
+  /// on that clock, every instant the clock CAN express is sooner than the wait
+  /// §8.1 mandates. There is therefore no deadline this may legally arm, and
+  /// `None` — do not schedule, do not transmit — is the only answer that is
+  /// never sooner than the floor.
+  ///
+  /// What it must NOT do is retain the caller's deadline as a consolation. That
+  /// is at most 250 ms out on the rename and §9 paths and about a second on
+  /// §8.2, so it discarded the MUST at exactly the moment the limiter existed to
+  /// hold one back.
+  ///
+  /// Saturating to the furthest representable instant is not the fix either, and
+  /// was considered: at the end of the clock that instant can be `now` itself,
+  /// which schedules the probe immediately — the flood, arriving by the door
+  /// meant to stop it.
+  ///
+  /// Read-only, and separate from [`Service::note_conflict`] for that reason:
+  /// the `Init` re-schedule in [`Service::handle_timeout`] also owes the floor,
+  /// and it must not record a fresh conflict every time it re-evaluates one.
+  ///
+  /// This never DEFERS a sequence the limit is not holding: with the latch off
+  /// the caller's deadline is returned untouched, overflow and all.
+  fn apply_backoff_floor(&self, now: I, deadline: Option<I>) -> Option<I> {
+    if !self.conflict_backoff {
+      return deadline;
+    }
+    let floor = now.checked_add_duration(CONFLICT_BACKOFF_MIN_WAIT)?;
+    Some(match deadline {
+      Some(d) => d.max(floor),
+      // Unreachable while every caller's own wait is shorter than the floor —
+      // a clock that cannot express `now + 1 s` cannot express `now + 5 s`
+      // either — and correct if one ever is not.
+      None => floor,
+    })
   }
 
   /// The most recently recorded conflict, or `None` if none has been.
@@ -2951,13 +2986,18 @@ where
   ///    to void: the RFC 6763 §9 meta-PTR is shared, claims nothing about this
   ///    instance, and its confirm only counts `responses_tx`;
   /// 8. the service is still on a clock — a regress that armed no deadline would
-  ///    strand it.
+  ///    strand it — UNLESS the clock cannot represent the wait §8.1's flood
+  ///    limit owes, in which case arming nothing is the REQUIRED outcome and
+  ///    being stranded is what failing closed looks like. The disjunct is the
+  ///    rule, not a hole in it: without it, a bounded clock reaching its end
+  ///    turns network input into a debug-build panic. See
+  ///    [`Service::apply_backoff_floor`].
   ///
   /// Debug-only: these are internal consistency facts and a release build pays
   /// nothing for them. `cargo test` builds with debug assertions on, so every
   /// test that drives any regress path checks the whole set.
   #[cfg(debug_assertions)]
-  fn assert_generation_replaced(&self) {
+  fn assert_generation_replaced(&self, now: I) {
     debug_assert_eq!(self.state, ServiceState::Init, "regress: state");
     debug_assert_eq!(self.probe_count, 0, "regress: probe_count");
     debug_assert_eq!(self.announce_count, 0, "regress: announce_count");
@@ -2986,7 +3026,8 @@ where
       "regress: a live commit token still carries lifecycle meaning"
     );
     debug_assert!(
-      self.lifecycle_deadline.is_some(),
+      self.lifecycle_deadline.is_some()
+        || now.checked_add_duration(CONFLICT_BACKOFF_MIN_WAIT).is_none(),
       "regress: no lifecycle deadline"
     );
   }
@@ -4257,7 +4298,14 @@ where
     // For the Init state: if lifecycle_deadline is None (e.g. renamed before
     // first handle_timeout), synthesise a fresh probe deadline now.
     if self.state == ServiceState::Init && self.lifecycle_deadline.is_none() {
-      self.lifecycle_deadline = probe_deadline(now, 0, &mut self.rng);
+      // Through the SAME floor the regress used. This is the one path that can
+      // fabricate a start time for a sequence that has none, so it is also the
+      // one path that could hand a latched flood a fresh 0-250 ms delay and undo
+      // the wait §8.1 mandates. With the floor applied it re-evaluates instead:
+      // `None` again while the clock still cannot express `now + 5 s`, and a
+      // properly floored deadline once it can.
+      let base = probe_deadline(now, 0, &mut self.rng);
+      self.lifecycle_deadline = self.apply_backoff_floor(now, base);
       // lifecycle didn't "fire" a transmit here — just scheduled; fall through.
     }
 

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -89,6 +89,10 @@ cfg_heap! {
   /// whatever sent it back. A §9 revert therefore meets both — this interval
   /// decides whether the revert happens, and [`CONFLICT_BACKOFF_MIN_WAIT`]
   /// floors the probe deadline that the revert, once allowed, arms.
+  ///
+  /// Both are scoped to ONE RECORD SET, which is the right scope for this rule —
+  /// §9's reset is about a specific conflicted record — and is short of the
+  /// scope §8.1's is stated at. [`CONFLICT_BURST_LEN`] states that shortfall.
   const CONFLICT_REPROBE_MIN_INTERVAL: core::time::Duration = core::time::Duration::from_secs(1);
 
   /// How many conflicts RFC 6762 §8.1 counts before its flood limit applies:
@@ -103,16 +107,44 @@ cfg_heap! {
   /// them means anything alone. What is counted is CONFLICTS — not renames and
   /// not probes — so the count spans renames and probe restarts, which is what
   /// makes it a limit on the rename loop rather than a counter that loop resets.
+  ///
+  /// # Scope: this counter is PER RECORD SET; §8.1 obliges the HOST
+  ///
+  /// The ring lives on one [`Service`], so what it bounds is the restarts of one
+  /// record set. That is narrower than the sentence quoted above, and the
+  /// difference is not academic — three ways past it are known:
+  ///
+  /// * conflicts are not aggregated across record sets. Fifteen entries spaced
+  ///   `d` apart span `14·d`, so a service whose restarts are slower than
+  ///   10/14 ≈ 0.714 s never latches at all, and N services contending at that
+  ///   rate put N × 1.4 restarts per second on the link between them;
+  /// * a freshly registered service starts with an empty ring, and is not slowed
+  ///   by another service's backoff already being in force;
+  /// * the history dies with the `Service`. A `HostConflict` is TERMINAL and is
+  ///   surfaced for the caller to intervene, and the usual intervention —
+  ///   unregister, then re-register under a new host name — hands the
+  ///   replacement a clean ring. A loop closed through the driver layer that way
+  ///   evades even the per-record-set latch.
+  ///
+  /// Closing this means moving the ring up to the `Endpoint` and sharing only
+  /// the verdict, which is tracked as issue #140. That would make the limit
+  /// ENDPOINT-wide — still not host-wide, because a second `Endpoint`, or a
+  /// second process, on the same machine is beyond anything this library can
+  /// observe.
   const CONFLICT_BURST_LEN: usize = 15;
 
   /// The period [`CONFLICT_BURST_LEN`] conflicts must fall inside for §8.1's
   /// flood limit to apply — and, once it applies, the span of total quiet that
-  /// releases it again.
+  /// releases it again. Measured over ONE record set's conflicts; see
+  /// [`CONFLICT_BURST_LEN`] for what that scope leaves open.
   const CONFLICT_BURST_WINDOW: core::time::Duration = core::time::Duration::from_secs(10);
 
   /// The floor §8.1 puts under the start of each successive probe sequence once
   /// [`CONFLICT_BURST_LEN`] conflicts have fallen inside one
   /// [`CONFLICT_BURST_WINDOW`]: "the host MUST wait at least five seconds".
+  ///
+  /// Imposed on the record set that counted them, not on the host — see
+  /// [`CONFLICT_BURST_LEN`].
   const CONFLICT_BACKOFF_MIN_WAIT: core::time::Duration = core::time::Duration::from_secs(5);
 }
 
@@ -1208,21 +1240,27 @@ cfg_heap! {
   /// instant of the last conflict-driven revert-to-probe, used to
   /// rate-limit RFC 6762 §9 re-probing under a conflict flood.
   last_conflict_reprobe: Option<I>,
-  /// The instants of the last [`CONFLICT_BURST_LEN`] conflicts that sent this
-  /// service back through RFC 6762 §8's startup steps, written round-robin at
-  /// `conflict_burst_slot`.
+  /// The instants of the last [`CONFLICT_BURST_LEN`] conflicts that sent THIS
+  /// SERVICE — this one record set — back through RFC 6762 §8's startup steps,
+  /// written round-robin at `conflict_burst_slot`.
   ///
   /// A fixed array and not a growing list, because the question it answers needs
   /// no more: §8.1 asks whether the FIFTEENTH-most-recent conflict is within
   /// [`CONFLICT_BURST_WINDOW`] of now, and a sixteenth timestamp cannot change
   /// that answer.
+  ///
+  /// Per record set is narrower than the host scope §8.1 states, and this ring
+  /// also dies with the `Service` that holds it. [`CONFLICT_BURST_LEN`] states
+  /// both gaps and names the issue that closes them.
   conflict_burst: [Option<I>; CONFLICT_BURST_LEN],
   /// Next slot to write in `conflict_burst` (wraps at [`CONFLICT_BURST_LEN`]).
   /// Once the ring has filled, that same slot holds its OLDEST entry — the
   /// fifteenth-most-recent conflict, which is the one §8.1's test reads.
   conflict_burst_slot: usize,
-  /// RFC 6762 §8.1's flood limit is in force: "the host MUST wait at least five
-  /// seconds before each successive additional probe attempt".
+  /// RFC 6762 §8.1's flood limit is in force FOR THIS RECORD SET: "the host MUST
+  /// wait at least five seconds before each successive additional probe
+  /// attempt". Per record set is narrower than the obligation that sentence
+  /// states — see [`CONFLICT_BURST_LEN`].
   ///
   /// LATCHED rather than recomputed per probe, and that is the whole point. Once
   /// the limit spaces probes five seconds apart, conflicts can only arrive that
@@ -2709,7 +2747,9 @@ where
   /// It is also where RFC 6762 §8.1's flood limit is applied, for the same
   /// reason: all three rules are conflict-driven probe attempts, this is where
   /// each one gets its start time, and a fourth added later inherits the limit
-  /// without knowing it exists. See [`Service::note_conflict`].
+  /// without knowing it exists. See [`Service::note_conflict`], and
+  /// [`CONFLICT_BURST_LEN`] for why that limit is currently narrower than §8.1
+  /// states it.
   ///
   /// What every caller passes, and nothing else:
   ///
@@ -2777,12 +2817,13 @@ where
     // so a §6.7 reply queued while announcing would otherwise put the full
     // positive-TTL record set on the wire during the regress.
     self.clear_response_cycle_state();
-    // RFC 6762 §8.1's flood limit: "If fifteen conflicts occur within any
-    // ten-second period, then the host MUST wait at least five seconds before
-    // each successive additional probe attempt." The caller's schedule is a
-    // FLOOR away from, never a ceiling on, what it asked for — §8.2's one-second
-    // deferral is still owed in full, it is simply not enough on its own once
-    // the limit is in force.
+    // RFC 6762 §8.1's flood limit, over THIS RECORD SET's conflicts rather than
+    // the host's (`CONFLICT_BURST_LEN` states the shortfall): "If fifteen
+    // conflicts occur within any ten-second period, then the host MUST wait at
+    // least five seconds before each successive additional probe attempt." The
+    // caller's schedule is a FLOOR away from, never a ceiling on, what it asked
+    // for — §8.2's one-second deferral is still owed in full, it is simply not
+    // enough on its own once the limit is in force.
     self.lifecycle_deadline = if self.note_conflict(now) {
       match (deadline, now.checked_add_duration(CONFLICT_BACKOFF_MIN_WAIT)) {
         (Some(d), Some(floor)) => Some(d.max(floor)),
@@ -2802,12 +2843,17 @@ where
     self.assert_generation_replaced();
   }
 
-  /// Fold one conflict into RFC 6762 §8.1's flood test, and report whether its
-  /// five-second floor is now in force.
+  /// Fold one conflict into RFC 6762 §8.1's flood test FOR THIS RECORD SET, and
+  /// report whether its five-second floor is now in force.
   ///
   /// > If fifteen conflicts occur within any ten-second period, then the host
   /// > MUST wait at least five seconds before each successive additional probe
   /// > attempt.
+  ///
+  /// That sentence obliges the HOST, and this counter covers one record set.
+  /// [`CONFLICT_BURST_LEN`] states the shortfall — no aggregation across record
+  /// sets, and no history across a `Service`'s lifetime — and names the issue
+  /// that closes it.
   ///
   /// Called from [`Service::restart_probe_cycle`] and therefore counting exactly
   /// the conflicts that put a fresh probe sequence on the wire — §9's revert,

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -82,8 +82,38 @@ cfg_heap! {
   /// Established/Announcing service (RFC 6762 §9 conflict rate-limiting). A
   /// conflict flood cannot reset us to Probing faster than this, so a hostile
   /// peer cannot prevent the service from ever (re)establishing.
+  ///
+  /// This is NOT the §8.1 flood limit below it, and both are live at once. This
+  /// one bounds how often an ESTABLISHED name may be sent back to probing at
+  /// all; §8.1's bounds how soon each restarted probe SEQUENCE may begin,
+  /// whatever sent it back. A §9 revert therefore meets both — this interval
+  /// decides whether the revert happens, and [`CONFLICT_BACKOFF_MIN_WAIT`]
+  /// floors the probe deadline that the revert, once allowed, arms.
   const CONFLICT_REPROBE_MIN_INTERVAL: core::time::Duration = core::time::Duration::from_secs(1);
 
+  /// How many conflicts RFC 6762 §8.1 counts before its flood limit applies:
+  ///
+  /// > If fifteen conflicts occur within any ten-second period, then the host
+  /// > MUST wait at least five seconds before each successive additional probe
+  /// > attempt.  This is to help ensure that, in the event of software bugs or
+  /// > other unanticipated problems, errant hosts do not flood the network with
+  /// > a continuous stream of multicast traffic.
+  ///
+  /// Fifteen, ten and five are one rule and are kept together because no one of
+  /// them means anything alone. What is counted is CONFLICTS — not renames and
+  /// not probes — so the count spans renames and probe restarts, which is what
+  /// makes it a limit on the rename loop rather than a counter that loop resets.
+  const CONFLICT_BURST_LEN: usize = 15;
+
+  /// The period [`CONFLICT_BURST_LEN`] conflicts must fall inside for §8.1's
+  /// flood limit to apply — and, once it applies, the span of total quiet that
+  /// releases it again.
+  const CONFLICT_BURST_WINDOW: core::time::Duration = core::time::Duration::from_secs(10);
+
+  /// The floor §8.1 puts under the start of each successive probe sequence once
+  /// [`CONFLICT_BURST_LEN`] conflicts have fallen inside one
+  /// [`CONFLICT_BURST_WINDOW`]: "the host MUST wait at least five seconds".
+  const CONFLICT_BACKOFF_MIN_WAIT: core::time::Duration = core::time::Duration::from_secs(5);
 }
 
 cfg_heap! {
@@ -1178,6 +1208,35 @@ cfg_heap! {
   /// instant of the last conflict-driven revert-to-probe, used to
   /// rate-limit RFC 6762 §9 re-probing under a conflict flood.
   last_conflict_reprobe: Option<I>,
+  /// The instants of the last [`CONFLICT_BURST_LEN`] conflicts that sent this
+  /// service back through RFC 6762 §8's startup steps, written round-robin at
+  /// `conflict_burst_slot`.
+  ///
+  /// A fixed array and not a growing list, because the question it answers needs
+  /// no more: §8.1 asks whether the FIFTEENTH-most-recent conflict is within
+  /// [`CONFLICT_BURST_WINDOW`] of now, and a sixteenth timestamp cannot change
+  /// that answer.
+  conflict_burst: [Option<I>; CONFLICT_BURST_LEN],
+  /// Next slot to write in `conflict_burst` (wraps at [`CONFLICT_BURST_LEN`]).
+  /// Once the ring has filled, that same slot holds its OLDEST entry — the
+  /// fifteenth-most-recent conflict, which is the one §8.1's test reads.
+  conflict_burst_slot: usize,
+  /// RFC 6762 §8.1's flood limit is in force: "the host MUST wait at least five
+  /// seconds before each successive additional probe attempt".
+  ///
+  /// LATCHED rather than recomputed per probe, and that is the whole point. Once
+  /// the limit spaces probes five seconds apart, conflicts can only arrive that
+  /// slowly too — so a condition re-derived from the ring would go false two
+  /// probes later and hand the flood its speed back, oscillating between a fast
+  /// burst and a clamped pair for as long as the peer keeps answering. "Each
+  /// successive additional probe attempt" is every one of them, not the next.
+  ///
+  /// It is released by the flood STOPPING and by nothing else: a whole
+  /// [`CONFLICT_BURST_WINDOW`] in which no conflict arrived at all. A rename does
+  /// not release it — §8.1 counts what was received, and renaming is the loop
+  /// being throttled, so resetting on rename is exactly the reset that would
+  /// defeat the limit.
+  conflict_backoff: bool,
   /// One-shot handoff of the OLD instance name's TTL=0 goodbye when a §9 conflict
   /// renames an ANNOUNCED service. Set at the rename site (`handle_timeout`) with
   /// the OLD records and WHICH instance records that name actually advertised
@@ -1292,6 +1351,9 @@ where
       awaiting_confirm: None,
       pending_legacy: std::vec::Vec::new(),
       last_conflict_reprobe: None,
+      conflict_burst: [None; CONFLICT_BURST_LEN],
+      conflict_burst_slot: 0,
+      conflict_backoff: false,
       rename_goodbye_handoff: None,
       meta_response_deadline: None,
       meta_questioner_srcs: std::vec::Vec::new(),
@@ -2644,12 +2706,20 @@ where
   /// impossible to miss, because a caller has none to spell. A FOURTH regress
   /// path added later gets the whole set by construction.
   ///
+  /// It is also where RFC 6762 §8.1's flood limit is applied, for the same
+  /// reason: all three rules are conflict-driven probe attempts, this is where
+  /// each one gets its start time, and a fourth added later inherits the limit
+  /// without knowing it exists. See [`Service::note_conflict`].
+  ///
   /// What every caller passes, and nothing else:
   ///
-  /// * `deadline` — when the fresh §8.1 sequence may begin. §9 and a rename use
-  ///   the randomized `probe_deadline`; §8.2's loser uses `now +
-  ///   TIEBREAK_DEFER_WAIT`, which is the one second it "defers to the winning
-  ///   host by waiting".
+  /// * `now` — the instant the conflict is being resolved at. It dates the
+  ///   conflict for §8.1's flood test and anchors that test's five-second floor.
+  /// * `deadline` — when the fresh §8.1 sequence may begin, IF the flood limit
+  ///   is not in force; when it is, the later of this and `now +
+  ///   CONFLICT_BACKOFF_MIN_WAIT`. §9 and a rename pass the randomized
+  ///   `probe_deadline`; §8.2's loser passes `now + TIEBREAK_DEFER_WAIT`, which
+  ///   is the one second it "defers to the winning host by waiting".
   /// * `renamed_from` — `Some(old records)` ONLY when the name is changing, so a
   ///   parked datagram's confirm latches ownership under the name it actually
   ///   advertised. `None` for the two SAME-name regressions, where ownership
@@ -2659,7 +2729,12 @@ where
   /// `last_conflict_reprobe` (its own rate limit), and a rename also calls
   /// `set_instance` and `reset_advertised_name_state` (per-advertised-NAME state,
   /// which a same-name regression must NOT reset — see `fully_announced`).
-  fn restart_probe_cycle(&mut self, deadline: Option<I>, renamed_from: Option<ServiceRecords>) {
+  fn restart_probe_cycle(
+    &mut self,
+    now: I,
+    deadline: Option<I>,
+    renamed_from: Option<ServiceRecords>,
+  ) {
     // A parked datagram belongs to the generation this regress replaces, so its
     // confirm must not advance the fresh §8.1 sequence: `Init → Probing(0)` costs
     // no datagram, so an old probe confirming into it would claim the name after
@@ -2702,9 +2777,92 @@ where
     // so a §6.7 reply queued while announcing would otherwise put the full
     // positive-TTL record set on the wire during the regress.
     self.clear_response_cycle_state();
-    self.lifecycle_deadline = deadline;
+    // RFC 6762 §8.1's flood limit: "If fifteen conflicts occur within any
+    // ten-second period, then the host MUST wait at least five seconds before
+    // each successive additional probe attempt." The caller's schedule is a
+    // FLOOR away from, never a ceiling on, what it asked for — §8.2's one-second
+    // deferral is still owed in full, it is simply not enough on its own once
+    // the limit is in force.
+    self.lifecycle_deadline = if self.note_conflict(now) {
+      match (deadline, now.checked_add_duration(CONFLICT_BACKOFF_MIN_WAIT)) {
+        (Some(d), Some(floor)) => Some(d.max(floor)),
+        // The caller's own arithmetic overflowed the clock. The floor is still a
+        // legal start for the sequence, and conjunct 8 below says a regress that
+        // armed nothing would strand the service.
+        (None, floor) => floor,
+        // …and the other way round: the floor overflowed where the caller's
+        // deadline did not, so keep the deadline rather than drop the service
+        // off the clock over a limit that is about slowing it down.
+        (Some(d), None) => Some(d),
+      }
+    } else {
+      deadline
+    };
     #[cfg(debug_assertions)]
     self.assert_generation_replaced();
+  }
+
+  /// Fold one conflict into RFC 6762 §8.1's flood test, and report whether its
+  /// five-second floor is now in force.
+  ///
+  /// > If fifteen conflicts occur within any ten-second period, then the host
+  /// > MUST wait at least five seconds before each successive additional probe
+  /// > attempt.
+  ///
+  /// Called from [`Service::restart_probe_cycle`] and therefore counting exactly
+  /// the conflicts that put a fresh probe sequence on the wire — §9's revert,
+  /// §8.2's deferral, §8.1's rename. A conflict the §9 rate limit already
+  /// dropped is not counted, because it caused no probe attempt for the limit to
+  /// space out; a `HostConflict` is not counted either, since it renames nothing
+  /// and re-probes nothing, it is surfaced to the caller.
+  ///
+  /// The clock is assumed monotonic, as [`crate::Instant`] requires. Where it is
+  /// not, both tests below fail CLOSED: a `now` that ran backwards neither
+  /// releases the latch nor engages it.
+  fn note_conflict(&mut self, now: I) -> bool {
+    // The flood has stopped if a whole window has gone by with no conflict at
+    // all. Tested BEFORE this conflict is folded in, and against the previous
+    // newest — so a fresh burst from a peer that had fallen quiet starts over
+    // from an empty ring at §8.1's ordinary 0-250 ms schedule, and a burst that
+    // is still going never reaches this at all (the limit spaces its probes five
+    // seconds apart, so its conflicts arrive well inside the window).
+    if let Some(newest) = self.newest_conflict()
+      && now
+        .checked_duration_since(newest)
+        .is_some_and(|since| since >= CONFLICT_BURST_WINDOW)
+    {
+      self.conflict_burst = [None; CONFLICT_BURST_LEN];
+      self.conflict_burst_slot = 0;
+      self.conflict_backoff = false;
+    }
+    if let Some(slot) = self.conflict_burst.get_mut(self.conflict_burst_slot) {
+      *slot = Some(now);
+      self.conflict_burst_slot = self.conflict_burst_slot.saturating_add(1) % CONFLICT_BURST_LEN;
+    }
+    // Once the cursor has advanced it addresses the ring's OLDEST entry: the
+    // fifteenth-most-recent conflict, and `None` until fifteen have arrived. If
+    // that one is within the window then all fifteen occurred inside a single
+    // ten-second period, which is the whole of §8.1's condition.
+    if let Some(Some(oldest)) = self.conflict_burst.get(self.conflict_burst_slot).copied()
+      && now
+        .checked_duration_since(oldest)
+        .is_some_and(|span| span <= CONFLICT_BURST_WINDOW)
+    {
+      self.conflict_backoff = true;
+    }
+    self.conflict_backoff
+  }
+
+  /// The most recently recorded conflict, or `None` if none has been.
+  fn newest_conflict(&self) -> Option<I> {
+    // `conflict_burst_slot` is the NEXT slot to write, so the newest entry sits
+    // one before it — wrapping to the last slot while the ring is still filling
+    // from zero, where it reads `None` anyway.
+    let newest = self
+      .conflict_burst_slot
+      .checked_sub(1)
+      .unwrap_or(CONFLICT_BURST_LEN.saturating_sub(1));
+    self.conflict_burst.get(newest).copied().flatten()
   }
 
   /// The post-state [`Service::restart_probe_cycle`] owes, checked as a SET on
@@ -3419,7 +3577,7 @@ where
         // renamed-away predecessor's §10.1 goodbye, and any goodbye this name
         // could cancel was already cancelled when it first fully announced.
         let deadline = probe_deadline(now, 0, &mut self.rng);
-        self.restart_probe_cycle(deadline, None);
+        self.restart_probe_cycle(now, deadline, None);
       }
       (ServiceState::Established | ServiceState::Announcing(_), ServiceEvent::Question(sq)) => {
         let src = sq.src();
@@ -3881,6 +4039,7 @@ where
         // deferral — so `renamed_from` is `None` and a parked datagram's records
         // still latch into `goodbye` under it.
         self.restart_probe_cycle(
+          now,
           now.checked_add_duration(schedule::rfc::TIEBREAK_DEFER_WAIT),
           None,
         );
@@ -3970,7 +4129,7 @@ where
             // window, between the stale-token capture the regress does first and
             // the per-name reset below.
             let deadline = probe_deadline(now, 0, &mut self.rng);
-            self.restart_probe_cycle(deadline, Some(renamed_from));
+            self.restart_probe_cycle(now, deadline, Some(renamed_from));
             self.records.set_instance(new_name.clone());
             let _ = self.pending_updates.insert(ServiceUpdate::Renamed(
               crate::event::ServiceRenamed::new(new_name),

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -11812,3 +11812,276 @@ fn a_host_aaaa_record_still_conflicts_when_we_own_an_aaaa_rrset() {
     "a different address inside an RRset we DO own is still a §9 conflict"
   );
 }
+
+// ── RFC 6762 §8.1's fifteen-conflicts-in-ten-seconds flood limit ─────
+
+/// Deliver one §9 conflict at an ESTABLISHED name: a peer's authoritative SRV
+/// for the name this service currently holds, on a port it does not publish.
+fn deliver_established_srv_conflict(
+  svc: &mut Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>>,
+  now: FakeInstant,
+) {
+  let owner = svc.name().as_str().to_owned();
+  let mut buf = std::vec::Vec::new();
+  make_srv_record_ref(&mut buf, &owner, 120, 0, 0, 9999, "host.local.");
+  let (rec, _) = Ref::try_parse(&buf, 0).unwrap();
+  let peer: core::net::SocketAddr = "192.168.1.50:5353".parse().unwrap();
+  svc.handle_event(
+    ServiceEvent::ProbeConflict(ProbeConflict::new(
+      peer,
+      rec,
+      dg(1),
+      ConflictHistory::Unmatched,
+      ConflictRole::Instance,
+    )),
+    now,
+  );
+}
+
+/// Drive one turn of §8.1's conflict → rename → re-probe loop, and report the
+/// instant the rename happened at together with the deadline it armed for the
+/// restarted probe sequence.
+///
+/// Time advances only as far as the state machine's own schedule asks — each
+/// step jumps straight to the armed `lifecycle_deadline` — because the rule
+/// under test is how fast this loop may turn. A fixture with a tick of its own
+/// would be deciding that instead of the code, and a coarse one would spread
+/// fifteen conflicts past the ten-second window the limit is measured over.
+fn one_conflict_turn(
+  svc: &mut Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>>,
+  from: FakeInstant,
+) -> (FakeInstant, FakeInstant) {
+  let mut buf = std::vec![0u8; 4096];
+  let mut now = from;
+  let mut on_wire = false;
+  for _ in 0..8 {
+    let due = svc
+      .lifecycle_deadline
+      .expect("the probe loop must stay on a clock");
+    now = core::cmp::max(now, due);
+    svc.handle_timeout(now).unwrap();
+    if let Ok(Some(_)) = svc.poll_transmit(now, &mut buf) {
+      svc.note_delivery(now, TransmitDelivery::ALL);
+      on_wire = true;
+      break;
+    }
+  }
+  assert!(
+    on_wire,
+    "no probe of the restarted sequence reached the wire; state={:?}",
+    svc.state()
+  );
+  // §8.1: a conflicting authoritative RESPONSE inside the probing window, from a
+  // host that already holds the name. The peer defends the new name every time,
+  // which is the persistent same-name peer the limit exists for.
+  deliver_losing_srv_conflict(svc, now, ConflictOrigin::AuthoritativeResponse);
+  assert!(
+    svc.probe_defeated,
+    "the response must classify as a §8.1 defeat"
+  );
+  // Spend the classification: this timeout is the rename.
+  svc.handle_timeout(now).unwrap();
+  let armed = svc
+    .lifecycle_deadline
+    .expect("a rename must re-arm the clock");
+  (now, armed)
+}
+
+/// RFC 6762 §8.1:
+///
+/// > If fifteen conflicts occur within any ten-second period, then the host MUST
+/// > wait at least five seconds before each successive additional probe attempt.
+///
+/// This is the loop, not the counter: a peer that defends every name this
+/// service renames itself to drove an unthrottled rename → announce → probe
+/// cycle, each turn putting packets on the link, because every post-rename probe
+/// was scheduled with §8.1's ordinary 0-250 ms STARTUP delay however many
+/// renames had already happened.
+///
+/// Below the threshold that delay is exactly right and is asserted to survive —
+/// the limit exists to stop a flood, not to slow ordinary conflict resolution
+/// down. At the fifteenth conflict and at every one after it the restarted
+/// sequence is at least five seconds out, which is what bounds the loop.
+///
+/// "Each successive additional probe attempt" is every subsequent one, so the
+/// turns past the threshold are asserted individually rather than once: a limit
+/// re-derived per probe from the ring alone would pass the fifteenth and then
+/// come off two turns later, because five-second spacing is itself too slow to
+/// keep fifteen conflicts inside ten seconds.
+#[test]
+fn a_conflict_flood_clamps_every_successive_probe_attempt() {
+  let mut svc = make_service(120);
+  let mut now = FakeInstant::zero();
+  for turn in 1..=14u32 {
+    let (at, armed) = one_conflict_turn(&mut svc, now);
+    assert!(
+      armed.0.saturating_sub(at.0) <= 250,
+      "turn {turn}: below §8.1's fifteenth conflict a rename keeps the ordinary \
+       0-250 ms probe delay; this one armed {} ms out",
+      armed.0.saturating_sub(at.0)
+    );
+    now = at;
+  }
+  assert!(
+    now.0 < 10_000,
+    "the fixture must land fourteen conflicts inside §8.1's ten-second window, \
+     or it is not testing the rule; it took {} ms",
+    now.0
+  );
+  let (at, armed) = one_conflict_turn(&mut svc, now);
+  assert!(
+    armed.0.saturating_sub(at.0) >= 5_000,
+    "the fifteenth conflict inside ten seconds completes §8.1's condition, so \
+     the restarted sequence owes at least five seconds; it armed {} ms out",
+    armed.0.saturating_sub(at.0)
+  );
+  now = at;
+  for turn in 16..=20u32 {
+    let (at, armed) = one_conflict_turn(&mut svc, now);
+    assert!(
+      armed.0.saturating_sub(at.0) >= 5_000,
+      "turn {turn}: the five-second floor is owed before EACH successive \
+       additional probe attempt, not only the next one; this one armed {} ms out",
+      armed.0.saturating_sub(at.0)
+    );
+    now = at;
+  }
+  // The count is what §8.1 says it is — conflicts — so it spans the renames it
+  // is throttling. Resetting it on a rename is precisely the reset that would
+  // defeat the limit, since renaming is the loop being bounded.
+  assert!(
+    svc.rename_attempt >= 20,
+    "twenty conflicts, twenty renames: got {}",
+    svc.rename_attempt
+  );
+}
+
+/// …and the limit comes off again when the flood does.
+///
+/// §8.1's floor answers a peer that keeps answering. Once that peer falls silent
+/// for a whole ten-second window the condition it created is spent, and the next
+/// conflict — here §9's, at a name that had gone on to establish — starts over
+/// at the ordinary 0-250 ms schedule. A latch that never released would leave a
+/// service permanently slow to re-verify its own name because of one bad ten
+/// seconds it had at startup.
+#[test]
+fn the_flood_limit_comes_off_once_the_flood_stops() {
+  let mut svc = make_service(120);
+  let mut now = FakeInstant::zero();
+  for _ in 0..15 {
+    let (at, _) = one_conflict_turn(&mut svc, now);
+    now = at;
+  }
+  assert!(svc.conflict_backoff, "the flood limit must be in force");
+  // The peer gives up: probing now completes and the name establishes.
+  let mut buf = std::vec![0u8; 4096];
+  let mut established = None;
+  for _ in 0..40 {
+    let due = svc.lifecycle_deadline.expect("still on a clock");
+    now = core::cmp::max(now, due);
+    svc.handle_timeout(now).unwrap();
+    if let Ok(Some(_)) = svc.poll_transmit(now, &mut buf) {
+      svc.note_delivery(now, TransmitDelivery::ALL);
+    }
+    if svc.state() == ServiceState::Established {
+      established = Some(now);
+      break;
+    }
+  }
+  let established = established.expect("the service must establish once unopposed");
+  // A full window of quiet, and then a fresh §9 conflict.
+  let at = established.advance(10_000);
+  deliver_established_srv_conflict(&mut svc, at);
+  assert_eq!(
+    svc.state(),
+    ServiceState::Init,
+    "§9's revert is owed whether or not the flood limit was ever in force"
+  );
+  assert!(
+    !svc.conflict_backoff,
+    "a whole ten-second window with no conflict at all ends the burst §8.1 \
+     measured, so the floor it imposed is spent"
+  );
+  let armed = svc.lifecycle_deadline.unwrap();
+  assert!(
+    armed.0.saturating_sub(at.0) <= 250,
+    "…and the restarted sequence is back on §8.1's ordinary 0-250 ms delay; it \
+     armed {} ms out",
+    armed.0.saturating_sub(at.0)
+  );
+}
+
+/// §9's conflict interval and §8.1's flood limit are DIFFERENT rules over
+/// different quantities, and both are live at once.
+///
+/// §9's `CONFLICT_REPROBE_MIN_INTERVAL` bounds how often an established name may
+/// be sent back to probing at all; §8.1's floor bounds how soon each restarted
+/// sequence may begin, whatever sent it back. This pins the first one at exactly
+/// its own interval with the flood counter cold, so the floor cannot be mistaken
+/// for it — and pins that a conflict the §9 interval DROPPED is counted by
+/// neither, because it caused no probe attempt for §8.1 to space out.
+#[test]
+fn the_section9_revert_interval_is_unchanged_by_the_flood_limit() {
+  let mut svc = make_service(120);
+  let now = drive_to_established(&mut svc);
+  svc.last_conflict_reprobe = Some(now);
+  deliver_established_srv_conflict(&mut svc, now.advance(999));
+  assert_eq!(
+    svc.state(),
+    ServiceState::Established,
+    "a §9 conflict inside CONFLICT_REPROBE_MIN_INTERVAL is still dropped"
+  );
+  assert_eq!(
+    svc.conflict_burst.iter().filter(|s| s.is_some()).count(),
+    0,
+    "…and a dropped conflict re-probes nothing, so §8.1's flood test — which is \
+     about probe attempts — does not count it"
+  );
+  let at = now.advance(1_000);
+  deliver_established_srv_conflict(&mut svc, at);
+  assert_eq!(
+    svc.state(),
+    ServiceState::Init,
+    "one millisecond further on, the interval is served and §9 reverts"
+  );
+  assert_eq!(
+    svc.conflict_burst.iter().filter(|s| s.is_some()).count(),
+    1,
+    "…and THAT one is counted: it armed a probe sequence"
+  );
+  let armed = svc.lifecycle_deadline.unwrap();
+  assert!(
+    armed.0.saturating_sub(at.0) <= 250,
+    "with one conflict counted the flood limit is nowhere near in force, so \
+     §9's revert keeps its ordinary 0-250 ms probe delay; it armed {} ms out",
+    armed.0.saturating_sub(at.0)
+  );
+}
+
+/// A slow drip is not a flood, however long it goes on.
+///
+/// §8.1 counts fifteen conflicts "within any ten-second period", not fifteen
+/// conflicts. A counter that only ever incremented — or one whose window was
+/// anchored at the first conflict rather than at the fifteenth-most-recent —
+/// would clamp a service that had merely been unlucky over several minutes.
+#[test]
+fn conflicts_spread_wider_than_the_window_never_clamp() {
+  let mut svc = make_service(120);
+  let mut now = FakeInstant::zero();
+  for turn in 1..=20u32 {
+    let (at, armed) = one_conflict_turn(&mut svc, now);
+    assert!(
+      armed.0.saturating_sub(at.0) <= 250,
+      "turn {turn}: one conflict per second is not fifteen inside ten seconds; \
+       it armed {} ms out",
+      armed.0.saturating_sub(at.0)
+    );
+    // The next conflict is a second away, so no ten-second period ever holds
+    // more than ten of them.
+    now = at.advance(1_000);
+  }
+  assert!(
+    !svc.conflict_backoff,
+    "twenty conflicts at one per second must never meet §8.1's condition"
+  );
+}

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -12085,3 +12085,196 @@ fn conflicts_spread_wider_than_the_window_never_clamp() {
     "twenty conflicts at one per second must never meet §8.1's condition"
   );
 }
+
+// ── §8.1's floor on a clock that runs out ───────────────────────────
+
+/// An [`crate::Instant`] on a BOUNDED clock: milliseconds from zero, with
+/// nothing past [`Self::CEILING`] representable.
+///
+/// Not a pathological fixture. `checked_add_duration` returns `Option` precisely
+/// because a clock may run out, so a bounded one is part of the contract this
+/// crate publishes — a wrapping millisecond counter is an ordinary choice for a
+/// bare-metal driver, and that is also where an unthrottled flood costs the
+/// most.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct BoundedInstant(u64);
+
+impl BoundedInstant {
+  const CEILING: u64 = 60_000;
+}
+
+impl crate::Instant for BoundedInstant {
+  fn checked_add_duration(self, dur: Duration) -> Option<Self> {
+    let ms = u64::try_from(dur.as_millis()).ok()?;
+    let t = self.0.checked_add(ms)?;
+    (t <= Self::CEILING).then_some(Self(t))
+  }
+
+  fn checked_duration_since(self, earlier: Self) -> Option<Duration> {
+    self.0.checked_sub(earlier.0).map(Duration::from_millis)
+  }
+}
+
+type BoundedService = Service<BoundedInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>>;
+
+/// A probing service on the bounded clock, with §8.1's floor latched or not.
+///
+/// The latch is set directly: how it engages is what the fifteen-conflict tests
+/// above are for, and these fixtures are about the clock.
+fn bounded_probing_service(start: BoundedInstant, latched: bool) -> BoundedService {
+  let mut svc: BoundedService = Service::try_new(
+    ServiceHandle::from_raw(0),
+    make_records(120),
+    start,
+    [0u8; 32],
+    true,
+    true,
+  );
+  svc.conflict_backoff = latched;
+  svc
+}
+
+/// Stage RFC 6762 §8.2's deferral at `at` and spend it: the peer's proposal
+/// sorts later, so this service loses, keeps its name, and owes one second of
+/// silence before the restarted sequence.
+///
+/// §8.2 rather than §8.1's rename because its wait is a FIXED one second. The
+/// rename's is a random 0-250 ms, which cannot say which overflow arm a fixture
+/// reached, and that is the whole question here.
+fn lose_bounded_tiebreak(svc: &mut BoundedService, at: BoundedInstant) {
+  let bytes = srv_txt_proposal(9999);
+  let peer: core::net::SocketAddr = "192.168.1.200:5353".parse().unwrap();
+  svc.handle_event(
+    ServiceEvent::ProbeProposal(probe_proposal(&bytes, peer, dg(1))),
+    at,
+  );
+  assert!(
+    svc.tiebreak_lost,
+    "the proposal must classify as a §8.2 loss for the fixture to mean anything"
+  );
+  svc.handle_timeout(at).unwrap();
+  assert_eq!(svc.state(), ServiceState::Init, "…and restart the sequence");
+}
+
+/// The control: while the clock can still express the floor, the floor is what
+/// gets armed — so "arms nothing" below cannot pass by being over-eager.
+#[test]
+fn a_representable_floor_is_armed_exactly() {
+  let mut svc = bounded_probing_service(BoundedInstant(0), true);
+  let at = BoundedInstant(BoundedInstant::CEILING - 10_000);
+  lose_bounded_tiebreak(&mut svc, at);
+  assert_eq!(
+    svc.lifecycle_deadline,
+    Some(BoundedInstant(at.0 + 5_000)),
+    "§8.2's one second is raised to §8.1's five, and not past them"
+  );
+}
+
+/// `(Some(deadline), None)`: the caller's own wait fits on this clock and
+/// §8.1's five seconds does not.
+///
+/// The old code kept the caller's deadline as a consolation — one second here,
+/// as little as 250 ms on the rename and §9 paths — which discarded the MUST at
+/// exactly the moment the limiter existed to hold a probe back. Nothing may be
+/// armed instead: every instant this clock can express is sooner than the wait
+/// §8.1 mandates.
+#[test]
+fn an_unrepresentable_floor_arms_nothing_rather_than_the_shorter_deadline() {
+  use crate::Instant as _;
+  let mut svc = bounded_probing_service(BoundedInstant(0), true);
+  let at = BoundedInstant(BoundedInstant::CEILING - 2_000);
+  assert!(
+    at.checked_add_duration(Duration::from_secs(1)).is_some(),
+    "the fixture must put §8.2's own one second INSIDE the clock…"
+  );
+  assert!(
+    at.checked_add_duration(Duration::from_secs(5)).is_none(),
+    "…and §8.1's floor outside it, or it is not testing the (Some, None) arm"
+  );
+  lose_bounded_tiebreak(&mut svc, at);
+  assert!(
+    svc.lifecycle_deadline.is_none(),
+    "an unrepresentable floor arms NOTHING; it armed {:?}",
+    svc.lifecycle_deadline
+  );
+
+  // …and it stays off the wire. The `Init` re-schedule is the one path that can
+  // fabricate a start time for a sequence that has none, so it is driven here
+  // rather than assumed inert.
+  let mut buf = std::vec![0u8; 4096];
+  svc.handle_timeout(at).unwrap();
+  assert!(
+    svc.lifecycle_deadline.is_none(),
+    "the Init re-schedule must not hand a latched flood a fresh 0-250 ms delay; \
+     it armed {:?}",
+    svc.lifecycle_deadline
+  );
+  assert!(
+    matches!(svc.poll_transmit(at, &mut buf), Ok(None)),
+    "nothing may go on the wire while the mandated wait cannot be scheduled"
+  );
+  let ceiling = BoundedInstant(BoundedInstant::CEILING);
+  svc.handle_timeout(ceiling).unwrap();
+  assert!(
+    svc.lifecycle_deadline.is_none(),
+    "…still true at the last instant this clock has"
+  );
+  assert!(
+    matches!(svc.poll_transmit(ceiling, &mut buf), Ok(None)),
+    "…and still nothing on the wire"
+  );
+}
+
+/// `(None, None)`: neither §8.2's deferral nor §8.1's floor is representable.
+///
+/// This case used to store `None` and then trip `assert_generation_replaced`, so
+/// a debug build turned a peer's proposal into a panic — reachable straight from
+/// network input. Passing under `cargo test`, which enables debug assertions, is
+/// half of what this asserts; the deadline is the other half.
+#[test]
+fn neither_the_deferral_nor_the_floor_representable_arms_nothing() {
+  use crate::Instant as _;
+  let mut svc = bounded_probing_service(BoundedInstant(0), true);
+  let kept = svc.name().as_str().to_owned();
+  let at = BoundedInstant(BoundedInstant::CEILING - 500);
+  assert!(
+    at.checked_add_duration(Duration::from_secs(1)).is_none(),
+    "the fixture must put §8.2's own one second outside the clock…"
+  );
+  assert!(
+    at.checked_add_duration(Duration::from_secs(5)).is_none(),
+    "…along with §8.1's floor, or it is not testing the (None, None) arm"
+  );
+  lose_bounded_tiebreak(&mut svc, at);
+  assert_eq!(
+    svc.name().as_str(),
+    kept,
+    "a §8.2 loss keeps the name, whatever the clock is doing"
+  );
+  assert!(
+    svc.lifecycle_deadline.is_none(),
+    "with neither wait representable, nothing may be armed; it armed {:?}",
+    svc.lifecycle_deadline
+  );
+  let mut buf = std::vec![0u8; 4096];
+  assert!(
+    matches!(svc.poll_transmit(at, &mut buf), Ok(None)),
+    "…and nothing goes on the wire"
+  );
+}
+
+/// With the latch OFF, the floor defers nothing — the fail-closed rule is scoped
+/// to the limit being in force, and applying it unconditionally would strand
+/// services that owe §8.1 no wait at all.
+#[test]
+fn an_unlatched_service_is_not_touched_by_the_floor() {
+  let mut svc = bounded_probing_service(BoundedInstant(0), false);
+  assert!(!svc.conflict_backoff, "the fixture starts unlatched");
+  let at = BoundedInstant(BoundedInstant::CEILING - 2_000);
+  lose_bounded_tiebreak(&mut svc, at);
+  assert_eq!(
+    svc.lifecycle_deadline,
+    Some(BoundedInstant(at.0 + 1_000)),
+    "§8.2's one second is owed in full and nothing else is"
+  );
+}


### PR DESCRIPTION
Closes #99. 
