### PR TITLE
fix(mdns-proto): one owner rule for §7.1 hints, and an NSEC only where provable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # UNRELEASED
 
+## §7.1 known-answer suppression works again for host addresses at a same-name service
+
+- `mdns-proto`: **behaviour-visible.** Where a service's instance name IS its
+  host name, an inbound A or AAAA known-answer could never suppress the matching
+  address record. The two halves of RFC 6762 §7.1 suppression classified the
+  same record differently: the emit-side filter mapped the CANDIDATE's rtype to
+  an owner role (PTR to the service type, SRV/TXT to the instance, A/AAAA to the
+  host), while ingest classified the ARRIVING record by NAME, walking the
+  service-type, instance and host names in that order with the first match
+  consuming. At a same-name service the instance arm matched first, so an A
+  known-answer was stamped `Instance` against an A candidate stamped `Host` and
+  the owner test could never hold. A querier that already held our address
+  record was sent it again on every query.
+- `mdns-proto`: the direction was benign — the failure was to suppress, so the
+  cost was one redundant but truthful record on a link where §7.1 is a
+  SHOULD-level bandwidth optimisation — and the fix does not trade it for the
+  opposite failure. Over-suppression silences an answer the querier does not
+  hold and nobody else will give, so the regression pins both: a known-answer
+  under an owner that is none of ours, and one at our instance name for a record
+  that lives at our host name, still suppress nothing.
+- `mdns-proto`: both halves now read ONE statement of the rule.
+  `respond::emitted_owner_name` says which of our owner names a record of a
+  given rtype sits at, and it lives beside the encoders that make it true —
+  `the_owner_name_rule_is_the_one_the_encoders_write_at` walks a real message and
+  puts every record either positive multicast encoder writes to it. Ingest binds
+  a hint by asking it for the ARRIVING record's rtype and requiring that record
+  to carry the name it names; the emit-side filter then needs no owner test at
+  all, because a stored hint of a given rtype is by construction a hint at that
+  rtype's owner name. `KasOwner` and the owner field on `KasHint` are gone with
+  the second copy of the rule.
+- `mdns-proto`: nothing changes for a service whose host name is a name of its
+  own. The one further difference is in hint STORAGE, and it can only reduce
+  work: a known-answer whose name is one of ours but whose rtype belongs to a
+  different one of our names — `_svc._tcp.local A x`, say — used to occupy a slot
+  in the sixteen-entry ring where it could never match a candidate, and is now
+  dropped on arrival.
+
 ## The §6.1 NSEC no longer denies address records the same announcement carries
 
 - `mdns-proto`: **wire-visible.** Where a service's instance name IS its host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # UNRELEASED
 
+## The §6.1 NSEC no longer denies address records the same announcement carries
+
+- `mdns-proto`: **wire-visible.** Where a service's instance name IS its host
+  name — supported, and what `Endpoint::host_addresses_disagree` is written to
+  keep legal — both positive multicast encoders put the A and AAAA records at
+  that name *and* an RFC 6762 §6.1 NSEC at that same owner asserting `{SRV,
+  TXT}`. The negative answer denied, with the cache-flush bit set, records the
+  very same datagram was handing over: a querier that believed it would not ask
+  again for those addresses until the negative cache entry expired. The bitmap
+  now names each address family the record set publishes at that name — `{SRV,
+  TXT, A}`, `{SRV, TXT, AAAA}` or `{SRV, TXT, A, AAAA}` as configured. Nothing
+  changes on the wire for a service whose host name is a name of its own, which
+  is every other deployment: `{SRV, TXT}` exactly, as before.
+- `mdns-proto`: **no completeness claim is made for that bitmap, and none should
+  be read into it.** It is what ONE `ServiceRecords` publishes at that name, and
+  a second route on the same endpoint can publish there without its knowing.
+  Registration compares instance names to instance names and host names to host
+  names and never across the two roles, and `Endpoint::host_addresses_disagree`
+  deliberately admits a sibling sharing a host name whenever the two publish
+  disjoint address families — so a sibling's AAAA at a name where this record set
+  has only A is still denied. What the change buys is the filed defect and only
+  it: the §6.1 negative no longer denies records the SAME record set publishes at
+  that name. It is also the narrower denial of the two bitmaps available at a
+  shared name, since `{SRV, TXT, A}` denies one address family where `{SRV, TXT}`
+  denied both. The cross-route cases need endpoint-wide owner state the proto
+  layer is not handed, and are tracked separately: a sibling or a cross-role
+  route publishing at this name (#147), a PTR at an instance name (#145), and an
+  NSEC outliving the owner that emitted it (#146).
+- `mdns-proto`: **not withheld**, because the record is a real negative response
+  rather than a decoration. `endpoint::route` matches a question against a
+  route's own unique names and, with answering enabled, routes it on the name
+  alone — there is no qtype filter — and the response cycle queues a reply for
+  any qtype. A query for an ABSENT type at an owned name therefore reaches the
+  responder, and the NSEC riding that reply is the only thing telling the querier
+  the type is not there; withholding it leaves silence and a retransmission
+  timeout. Withholding would also not reach the cross-route cases it would be
+  traded for: `instance == host` is the only test one record set can run, and it
+  cannot see a second route whose HOST name is our INSTANCE name — a name this
+  encoder writes at either way.
+- `mdns-proto`: the emitted bitmap and the locally recognised one now derive
+  from **one** function. `respond::instance_rrset_types` is the single statement
+  of what a record set puts at its instance name, and
+  `respond::emitted_nsec_types` is what the §6.1 record asserts there. Emission,
+  the `emitted_nsec_identity` the endpoint's relinquished-RRset screen retains,
+  and `our_nsec_identities` all read it, so the emitted identity can no longer
+  disagree with the recognised one. Recognition stays deliberately **wider** than
+  emission: an NSEC arriving at a name we are probing is adjudicated whether or
+  not we would have written that exact bitmap, so an RFC 6762 §9 twin's bare
+  `{SRV, TXT}` at a name that also holds addresses still counts as identical
+  rdata — narrowing that would let a twin win §8.1 against us. History narrows in
+  step with emission instead: `transmitted_rdata_forms` names the one bitmap the
+  encoder wrote and no other, which is the direction that cannot suppress a
+  genuine peer's conflict.
+
 ## A persistent same-name peer no longer drives one record set's rename loop unthrottled
 
 - `mdns-proto`: a `Service` now applies RFC 6762 §8.1's flood limit — "if
@@ -222,11 +276,18 @@
   unimplemented and a `Service` exposes no records mutator, a duplicate instance
   name and a name a collision goodbye still holds are both refused, and a live
   route publishing the same host name with a different A or AAAA set makes the
-  registration fail outright. The negative assertions are covered too — the
-  encoder emits exactly one §6.1 NSEC per service, owned by the INSTANCE name, so
-  no sibling registration can flip a host-name NSEC's truth. Nothing this
-  endpoint had asserted changed truth-value there, so the advance asserted
-  something false about its own records. With a superseded credit now a standing
+  registration fail outright. The negative assertions are covered too, though
+  more narrowly than this entry once claimed: the encoder emits exactly one §6.1
+  NSEC per service, owned by the INSTANCE name, and a registration changes
+  neither the bytes an existing route has asserted nor the record set those
+  bytes describe. Whether such a bitmap is still ACCURATE for the whole link is a
+  separate question, and a registration CAN change that answer — nothing stops a
+  new route taking an existing instance name as its HOST name, because the guards
+  compare instance to instance and host to host and never across the two roles
+  (#147). Accuracy is not what the self-send generation tracks, though: it tracks
+  whether these bytes are still what this endpoint publishes, and they are.
+  Nothing this endpoint had asserted stopped being its own, so the advance
+  asserted something false about its own records. With a superseded credit now a standing
   tombstone, that falsehood was expensive rather than free: one unrelated
   registration denied §10 observation and §7.1/§7.3 quieting to EVERY
   byte-identical copy of a live service's own bytes for the whole recency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,37 @@
   encoder wrote and no other, which is the direction that cannot suppress a
   genuine peer's conflict.
 
+## A known answer no longer suppresses past its own expiry
+
+- `mdns-proto`: **behaviour-visible.** Both RFC 6762 §7.1 suppression paths
+  decided whether a known answer was still held WITHOUT consulting the clock
+  `poll_transmit` was handed, so a conforming Sans-I/O caller — one that queues a
+  response and polls it with no `handle_event` or `handle_timeout` in between —
+  could withhold a record the querier no longer had. §7.1 licenses suppression
+  only for a record the querier STILL holds, and over-suppression is the
+  terminal direction: the answer is not sent, and nobody else on the link will
+  send it.
+- `mdns-proto`: the ordinary hint path compared each `KasHint::expires_at`
+  against `last_now`, a field refreshed only by `handle_event` and
+  `handle_timeout`, so it could sit arbitrarily far behind the caller's real
+  instant. `poll_transmit` already receives `now`; the filter now reads it, and
+  `last_now` is documented as what it actually remains for — the instant
+  `poll_timeout` names to report a service due immediately.
+- `mdns-proto`: the RFC 6763 §9 meta-query path stored no expiry at all.
+  `meta_known_answered` was a bare `bool`, set when a meta questioner's
+  known-answer section carried the meta-PTR for our service type and read back
+  as unconditional suppression however much later the reply was polled. The
+  arriving record's TTL was checked against the §7.1 half-TTL threshold on
+  arrival — which says the answer is fresh ENOUGH to suppress, not for how long.
+  With an authoritative TTL of 2 s and a 1 s known answer, a caller polling more
+  than a second later left the querier with no service-type enumeration response.
+  The field now holds the deadline, computed the way `KasHint::expires_at` is —
+  the record's own TTL from the instant its event carried, with an
+  un-representable sum dropping the hint rather than counting as valid — and
+  `poll_transmit` requires it to be ahead of its own `now`.
+- `mdns-proto`: nothing changes for a caller that polls on the instant it fired
+  the timeout, which is what the bundled drivers do.
+
 ## A persistent same-name peer no longer drives one record set's rename loop unthrottled
 
 - `mdns-proto`: a `Service` now applies RFC 6762 §8.1's flood limit — "if

--- a/mdns-proto/src/endpoint/tests.rs
+++ b/mdns-proto/src/endpoint/tests.rs
@@ -12997,10 +12997,11 @@ fn build_instance_nsec_response(buf: &mut [u8], owner: &Name, types: &[u16]) -> 
 /// HISTORY ASSERTS TRANSMITTED BYTES, NOT CLASSIFIER-ACCEPTED FORMS.
 ///
 /// `respond::canonical_rdata_forms` names TWO instance-NSEC bitmaps where the
-/// instance name is also the host name and addresses are published: the fixed
-/// `{SRV, TXT}` this crate's encoder writes, and the accurate `{SRV, TXT, A,
-/// AAAA}` a CONFORMING responder writes at a name that really does hold all
-/// four. Accepting both is right for the LIVE classifier — such a twin is
+/// instance name is also the host name and addresses are published: the
+/// `{SRV, TXT, A, AAAA}` this crate's encoder writes there — the addresses are at
+/// that very name, so the negative answer may not deny them — and the bare
+/// `{SRV, TXT}` a §9 twin treating it as an ordinary instance name writes.
+/// Accepting both is right for the LIVE classifier: such a twin is
 /// indistinguishable from us there, and RFC 6762 §9's identical-rdata rule
 /// protects it from our rename.
 ///
@@ -13008,11 +13009,11 @@ fn build_instance_nsec_response(buf: &mut [u8], owner: &Name, types: &[u16]) -> 
 /// factual: these exact bytes left this endpoint, on this family, in this
 /// generation. Expanding the exposure BOOLEAN through the live list made the
 /// screen answer for a form no `push_service_nsec` ever encoded, so a GENUINE
-/// twin's conforming NSEC read as an old self-echo and the §8.1 / §9 conflict
-/// against the successor was withheld for the whole retention window.
+/// twin's NSEC read as an old self-echo and the §8.1 / §9 conflict against the
+/// successor was withheld for the whole retention window.
 ///
-/// The screen must be NARROWED, not disabled: our own `{SRV, TXT}` echo is
-/// still disowned.
+/// The screen must be NARROWED, not disabled: the bitmap this endpoint really
+/// did write is still disowned as its own echo.
 #[test]
 fn a_conforming_nsec_this_endpoint_never_encoded_is_not_disowned_as_its_own_echo() {
   use crate::wire::ResourceType;
@@ -13052,7 +13053,7 @@ fn a_conforming_nsec_this_endpoint_never_encoded_is_not_disowned_as_its_own_echo
   assert_eq!(
     crate::service::canonical_rdata_forms(&relinquished, ResourceType::Nsec).len(),
     2,
-    "the live classifier must still accept the conforming twin's bitmap — this \
+    "the live classifier must still accept the twin's narrower bitmap — this \
      test is about who ELSE may read that list"
   );
   assert_eq!(
@@ -13073,7 +13074,12 @@ fn a_conforming_nsec_this_endpoint_never_encoded_is_not_disowned_as_its_own_echo
   .unwrap();
 
   let mut buf = [0u8; 512];
-  let emitted_types = [ResourceType::Srv.to_u16(), ResourceType::Txt.to_u16()];
+  let emitted_types = [
+    ResourceType::Srv.to_u16(),
+    ResourceType::Txt.to_u16(),
+    ResourceType::A.to_u16(),
+    ResourceType::AAAA.to_u16(),
+  ];
   let n = build_instance_nsec_response(&mut buf, &name, &emitted_types);
   assert_eq!(
     probe_disowned_from(&mut e, &buf[..n], now, "192.168.1.99:5353"),
@@ -13082,18 +13088,13 @@ fn a_conforming_nsec_this_endpoint_never_encoded_is_not_disowned_as_its_own_echo
      screen is narrowed, not disabled"
   );
 
-  let conforming_types = [
-    ResourceType::Srv.to_u16(),
-    ResourceType::Txt.to_u16(),
-    ResourceType::A.to_u16(),
-    ResourceType::AAAA.to_u16(),
-  ];
-  let n = build_instance_nsec_response(&mut buf, &name, &conforming_types);
+  let twin_types = [ResourceType::Srv.to_u16(), ResourceType::Txt.to_u16()];
+  let n = build_instance_nsec_response(&mut buf, &name, &twin_types);
   assert_eq!(
     probe_unscreened_from(&mut e, &buf[..n], now, "192.168.1.99:5353"),
     std::vec![successor],
-    "a conforming responder's ACCURATE bitmap is a form this endpoint never put \
-     on any wire, so no history of ours may label it — labelling it would cost \
+    "a §9 twin's narrower bitmap is a form this endpoint never put on any wire \
+     at this name, so no history of ours may label it — labelling it would cost \
      the peer that sent it §8.1's immediate rename of our successor"
   );
 

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -1347,10 +1347,19 @@ cfg_heap! {
   /// inject a known-answer that suppresses our meta reply. Bounded by
   /// `MAX_QUESTIONER_SRCS`; cleared when the meta reply fires or is suppressed.
   meta_questioner_srcs: std::vec::Vec<core::net::SocketAddr>,
-  /// (RFC 6763 §9 + §7.1): set when a meta questioner's known-answer
-  /// section already carries the meta-PTR for OUR service type — our pending
-  /// meta reply is then suppressed. Reset each meta cycle.
-  meta_known_answered: bool,
+  /// (RFC 6763 §9 + §7.1): when a meta questioner's known-answer section
+  /// already carries the meta-PTR for OUR service type, the instant that
+  /// known answer STOPS being one — the arriving record's own TTL counted from
+  /// the instant its event carried. Our pending meta reply is suppressed only
+  /// while `now` is still before it. Reset each meta cycle.
+  ///
+  /// A deadline rather than a flag for the same reason `KasHint::expires_at` is
+  /// one: §7.1 licenses withholding only a record the querier STILL holds, and a
+  /// conforming Sans-I/O caller may queue the meta reply and poll it with no
+  /// `handle_event` or `handle_timeout` in between, so an unconditional flag
+  /// could silence a service-type enumeration whose known answer had already
+  /// lapsed — leaving the querier with no answer at all, from us or from anyone.
+  meta_known_answered: Option<I>,
   /// Test-only: silence [`Service::assert_no_live_commit_token`] so a test can
   /// drive the entry points the way a NON-COMPLIANT driver would and pin what
   /// the release-mode backstops actually do. Those backstops only exist for a
@@ -1441,7 +1450,7 @@ where
       rename_goodbye_handoff: None,
       meta_response_deadline: None,
       meta_questioner_srcs: std::vec::Vec::new(),
-      meta_known_answered: false,
+      meta_known_answered: None,
       #[cfg(test)]
       contract_assertions_off: false,
     }
@@ -2632,7 +2641,7 @@ where
     // answer the meta-query while not authoritative.
     self.meta_response_deadline = None;
     self.meta_questioner_srcs.clear();
-    self.meta_known_answered = false;
+    self.meta_known_answered = None;
   }
 
   /// clear the state that is about a NAME, on a conflict-driven RENAME. The NEW
@@ -3930,7 +3939,21 @@ where
             && let Ok(crate::wire::Rdata::Ptr(p)) = ka.record().rdata_view()
             && crate::endpoint::names_match(self.records.service_type(), p.target())
           {
-            self.meta_known_answered = true;
+            // Date the hint, exactly as the ordinary §7.1 path dates a
+            // `KasHint`: the arriving record's own TTL from the instant this
+            // event carries. The half-TTL test above says the answer is fresh
+            // ENOUGH to suppress; it does not say for how long, and
+            // `poll_transmit` runs on a clock of its own.
+            //
+            // An un-representable deadline drops the hint rather than counting
+            // as valid: a TTL that overflows the clock is not evidence the
+            // querier holds anything, and failing to suppress costs one
+            // redundant but truthful meta-PTR, where suppressing wrongly costs
+            // the enumeration entirely.
+            let ttl = core::time::Duration::from_secs(u64::from(ka.record().ttl()));
+            if let Some(expires_at) = now.checked_add_duration(ttl) {
+              self.meta_known_answered = Some(expires_at);
+            }
           }
           return;
         }
@@ -4624,9 +4647,13 @@ where
       // this window — mirrors the guard for the normal response path. With several
       // coalesced meta queriers a single source that already has our type must
       // NOT suppress the multicast reply the others still need.
-      let suppressed = self.meta_known_answered && self.meta_questioner_srcs.len() == 1;
+      // Expiry is judged against THIS call's `now`, never a cached one, and
+      // never on the flag alone — see the field. A known answer that has lapsed
+      // by the time the jittered reply is polled suppresses nothing.
+      let suppressed = self.meta_known_answered.is_some_and(|until| now < until)
+        && self.meta_questioner_srcs.len() == 1;
       self.meta_questioner_srcs.clear();
-      self.meta_known_answered = false;
+      self.meta_known_answered = None;
       if !suppressed
         && let Ok(meta) = crate::Name::try_from_str(crate::endpoint::DNS_SD_META_QUERY_NAME)
         && let Ok(n) = respond::write_meta_response(&self.records, &meta, buf)

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -18,26 +18,22 @@ mod state;
 cfg_heap! {}
 
 cfg_heap! {
-  /// Which of OUR owner names a known-answer's record name matched. §7.1
-  /// suppression is per RRset, and an RRset is identified by (name, type, class,
-  /// rdata). A known-answer with our rtype + rdata but a DIFFERENT owner name is a
-  /// DIFFERENT RRset and must NOT suppress our record — otherwise a querier could
-  /// silence our `host.local A x` by sending a same-rdata `_svc._tcp.local A x`.
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-  enum KasOwner {
-    /// The shared service-type name (owns the PTR).
-    ServiceType,
-    /// The service instance name (owns SRV + TXT).
-    Instance,
-    /// The host name (owns A + AAAA).
-    Host,
-  }
-
-  /// A single observed known-answer hint. KAS suppression checks records
-  /// against this list before emitting.
+  /// A single observed known-answer hint. §7.1 suppression checks each
+  /// candidate record against this list before emitting it.
+  ///
+  /// THERE IS NO OWNER FIELD, and that absence is the rule. RFC 6762 §7.1
+  /// identifies an RRset by (name, type, class, rdata), so a hint may suppress
+  /// one of our records only when it names the very owner that record sits at —
+  /// and [`respond::emitted_owner_name`] already answered that from the rtype
+  /// when the hint was ADMITTED, rejecting anything arriving at another name. A
+  /// stored hint is therefore a hint at the owner its rtype implies, and
+  /// matching the rtype IS matching the owner.
+  ///
+  /// While the owner was carried here it was classified TWICE by two different
+  /// rules — by name on the way in, by rtype on the way out — and the two
+  /// disagreed wherever a service's instance name is also its host name.
   #[derive(Debug, Clone, Copy)]
   struct KasHint<I> {
-    owner: KasOwner,
     rtype: crate::wire::ResourceType,
     rdata_hash: u64,
     expires_at: I,
@@ -3988,24 +3984,30 @@ where
           Err(_) => return, // malformed rdata / pointer cycle — drop the hint
         };
         let rdata_hash = hash_rdata(&canonical);
-        // a known-answer may only suppress an RRset WE own, so bind the
-        // hint to which of our owner names its record name matches. A KA whose
-        // name is none of ours suppresses nothing (dropped here); one whose name
-        // matches but under the wrong type (e.g. `_svc._tcp.local A x`) is kept
-        // but will never match a candidate, because the filter pairs each
-        // candidate's owner-kind with its rtype.
-        let owner = if crate::endpoint::names_match_record(self.records.service_type(), ka.record())
-        {
-          KasOwner::ServiceType
-        } else if crate::endpoint::names_match_record(self.records.instance(), ka.record()) {
-          KasOwner::Instance
-        } else if crate::endpoint::names_match_record(self.records.host(), ka.record()) {
-          KasOwner::Host
-        } else {
-          return; // not one of our RRset names — cannot suppress any of our records
+        // A known-answer may only suppress the RRset it actually NAMES — §7.1
+        // identifies one by name, type, class and rdata — so bind the hint by
+        // asking `respond::emitted_owner_name` which of our names a record of
+        // THIS rtype sits at, then requiring the arriving record to carry that
+        // name. A type these encoders never write has no such owner, and a
+        // record at any other name is a different RRset; either way it can
+        // suppress nothing, so it is dropped here rather than stored to be
+        // filtered out later.
+        //
+        // Deriving the owner from the RTYPE is what keeps this side and the
+        // emit-side filter from disagreeing: they read ONE rule, so the filter
+        // needs no owner test of its own. Classifying by NAME here — walking our
+        // three names in a precedence order, first match consuming — is what
+        // broke where the instance name IS the host name: an inbound A took the
+        // instance arm because that name matched first, while the A candidate
+        // was owned by the host, and §7.1 suppression for host addresses could
+        // never fire.
+        let Some(owner) = respond::emitted_owner_name(&self.records, ka.record().rtype()) else {
+          return; // a type these encoders never write — nothing of ours to suppress
         };
+        if !crate::endpoint::names_match_record(owner, ka.record()) {
+          return; // a different owner name is a different RRset (§7.1)
+        }
         let hint = KasHint {
-          owner,
           rtype: ka.record().rtype(),
           rdata_hash,
           expires_at,
@@ -4846,23 +4848,14 @@ where
               Some(t) => t,
               None => return false,
             };
-            // a hint may only suppress the RRset it actually names. Map
-            // this candidate's owner to its kind (PTR↦service-type, SRV/TXT↦
-            // instance, A/AAAA↦host) and require the hint to share it — so a
-            // same-rtype/same-rdata known-answer under a DIFFERENT owner name
-            // cannot silence our record.
-            let owner = match rtype {
-              crate::wire::ResourceType::Ptr => KasOwner::ServiceType,
-              crate::wire::ResourceType::Srv | crate::wire::ResourceType::Txt => KasOwner::Instance,
-              crate::wire::ResourceType::A | crate::wire::ResourceType::AAAA => KasOwner::Host,
-              _ => return false,
-            };
+            // A hint may only suppress the RRset it actually names, and a stored
+            // hint was already bound to the owner name its rtype sits at — see
+            // `respond::emitted_owner_name`, which is what admitted it. So
+            // matching the rtype here IS matching the owner, and there is no
+            // second classification left to disagree with the first.
             let suppressed = hints.iter().any(|slot| match slot {
               Some(hint) => {
-                hint.owner == owner
-                  && hint.rtype == rtype
-                  && hint.rdata_hash == h
-                  && hint.expires_at > now_ref
+                hint.rtype == rtype && hint.rdata_hash == h && hint.expires_at > now_ref
               }
               None => false,
             });

--- a/mdns-proto/src/service/mod.rs
+++ b/mdns-proto/src/service/mod.rs
@@ -1081,9 +1081,16 @@ cfg_heap! {
   rng: Rng,
   pending_tx: TQ,
   pending_updates: EV,
-  /// Most-recently-seen `now`, cached for use by `poll_transmit`'s KAS
-  /// filtering closure. Updated by both `handle_timeout` and `handle_event`
-  /// (`handle_event` now takes `now` directly).
+  /// Most-recently-seen `now`, kept for [`Self::poll_timeout`] — the one
+  /// clock-sensitive method with no `now` of its own. It answers "due
+  /// immediately" by naming an instant in the past, and this is the only
+  /// instant it has. Set at construction and refreshed by `handle_timeout` and
+  /// `handle_event`.
+  ///
+  /// It is NOT a clock for anything that receives one. A method given `now`
+  /// reads its parameter: this field only tracks the last call that happened to
+  /// carry an instant, and a caller may poll any number of times in between, so
+  /// it is a lower bound on the real time and never the real time.
   last_now: Option<I>,
   /// Ring buffer of observed known-answer hints (RFC 6762 §7.1).
   kas_hints: [Option<KasHint<I>>; KAS_RING_SIZE],
@@ -3465,9 +3472,10 @@ where
     #[cfg(feature = "tracing")]
     let _span = hick_trace::trace_span!("service", handle = self.handle.raw()).entered();
     self.assert_no_live_commit_token("Service::handle_event");
-    // always refresh last_now so that subsequent calls (e.g.
-    // Question→response_deadline, KnownAnswer→expiry) use a current reference
-    // even when handle_timeout has not recently fired.
+    // Refresh the instant `poll_timeout` reports as "due immediately" — an
+    // event can make a service due (a Question arms `response_deadline`) with
+    // no `handle_timeout` between it and the next `poll_timeout`. The arms
+    // below read this method's `now`, not this field.
     self.last_now = Some(now);
     trace!(
       target: "mdns_proto::service",
@@ -3956,10 +3964,6 @@ where
           return;
         }
 
-        // Item 5: store the KAS hint with expiration based on the record's TTL.
-        // `now` is available directly (parameter).
-        let last_now = now;
-
         // RFC 6762 §7.1 half-TTL rule: a known-answer MUST NOT suppress our
         // record if the querier's remaining TTL is less than half of our
         // authoritative TTL — their cache is about to expire, so suppressing
@@ -3971,8 +3975,10 @@ where
           return;
         }
 
+        // The hint expires on the arriving record's own TTL, counted from the
+        // instant this event carries.
         let ttl = core::time::Duration::from_secs(u64::from(ka.record().ttl()));
-        let expires_at = match last_now.checked_add_duration(ttl) {
+        let expires_at = match now.checked_add_duration(ttl) {
           Some(t) => t,
           None => return,
         };
@@ -4123,9 +4129,8 @@ where
     #[cfg(feature = "tracing")]
     let _span = hick_trace::trace_span!("service", handle = self.handle.raw()).entered();
     self.assert_no_live_commit_token("Service::handle_timeout");
-    // Cache latest `now` for use by poll_transmit's KAS filtering closure.
-    // handle_event now receives `now` directly, so this is only needed
-    // for the filtering closure in poll_transmit.
+    // Refresh the instant `poll_timeout` reports as "due immediately"; every
+    // other clock-sensitive path is handed a `now` of its own and reads that.
     self.last_now = Some(now);
 
     // Item 5: prune expired KAS hints.
@@ -4837,26 +4842,30 @@ where
         // path where peer B's hint suppresses peer A's answer.
         let single_questioner = self.questioner_srcs.len() <= 1;
         let hints = self.kas_hints;
-        let last_now = self.last_now;
         let (encoded, emitted) =
           respond::write_announce_filtered(&self.records, buf, |rtype, rdata| {
             if !single_questioner {
               return false;
             }
             let h = hash_rdata(rdata);
-            let now_ref = match last_now {
-              Some(t) => t,
-              None => return false,
-            };
+            // Expiry is judged against THIS call's `now`, never a cached one. A
+            // hint suppresses on the claim that the querier still holds the
+            // record, and that claim expires on the clock the caller is holding:
+            // a conforming Sans-I/O caller may queue a response and poll it with
+            // no `handle_event` or `handle_timeout` in between, so any cached
+            // instant can sit arbitrarily far behind the real one and keep an
+            // expired hint alive. Over-suppression is the terminal direction —
+            // §7.1 licenses withholding only a record the querier still has, and
+            // nobody else will send this one — so the parameter is the only
+            // admissible reading.
+            //
             // A hint may only suppress the RRset it actually names, and a stored
             // hint was already bound to the owner name its rtype sits at — see
             // `respond::emitted_owner_name`, which is what admitted it. So
             // matching the rtype here IS matching the owner, and there is no
             // second classification left to disagree with the first.
             let suppressed = hints.iter().any(|slot| match slot {
-              Some(hint) => {
-                hint.rtype == rtype && hint.rdata_hash == h && hint.expires_at > now_ref
-              }
+              Some(hint) => hint.rtype == rtype && hint.rdata_hash == h && hint.expires_at > now,
               None => false,
             });
             #[cfg(feature = "stats")]

--- a/mdns-proto/src/service/respond.rs
+++ b/mdns-proto/src/service/respond.rs
@@ -183,48 +183,41 @@ pub(crate) fn write_probe(records: &ServiceRecords, out: &mut [u8]) -> Result<us
 }
 
 /// RFC 6762 §6.1 ("negative responses"): append an NSEC record for the service
-/// INSTANCE name to the Additional section, asserting the exact set of record
-/// types that exist there — `{SRV, TXT}`. A querier asking the instance name
-/// for any other type then receives an authoritative "no such record" instead
-/// of waiting out a retransmission timeout. The NSEC "Next Domain Name" is the
-/// owner name itself (§6.1), and the cache-flush bit is set (the instance SRV
-/// and TXT are unique records, §10.2).
+/// INSTANCE name to the Additional section, asserting the record types this
+/// record set publishes there. A querier asking that name for another type then
+/// receives a "no such record" answer instead of waiting out a retransmission
+/// timeout. The NSEC "Next Domain Name" is the owner name itself
+/// (§6.1), and the cache-flush bit is set (the records it describes are unique,
+/// §10.2).
 ///
-/// Only the instance NSEC is emitted — deliberately NOT a host NSEC. The
-/// instance name is owned by exactly one service (a duplicate instance name is
-/// a §9 conflict that triggers a rename), so `{SRV, TXT}` is provably the
-/// complete RRset and the negative is always accurate. The HOST name, by
-/// contrast, can be shared by several local services that advertise DIFFERENT
-/// address families (e.g. one IPv4-only, one IPv6-only — see the shared-host
-/// goodbye logic). This per-service encoder sees only its own `ServiceRecords`,
-/// so it cannot prove the host's complete address-family set; emitting a
-/// cache-flushed host NSEC from that partial view could publish a false
-/// negative (deny AAAA while a sibling actually owns it). Proving host
-/// completeness needs endpoint-wide union state the proto layer does not have,
-/// so the host NSEC is omitted rather than risk an inaccurate authoritative
-/// denial.
+/// WHAT it asserts is [`emitted_nsec_types`], the one home of that rule. This
+/// function only encodes the answer, so it cannot disagree with the recognition
+/// side about what our own NSEC says.
 ///
-/// Best-effort: the NSEC is an optional hint, so if it does not fit
-/// the remaining buffer the builder is rolled back to before it and the
-/// positive answers already written are sent unchanged — adding the hint must
-/// never turn a deliverable response into a dropped one.
+/// Only the instance NSEC is ever emitted, never a host NSEC: `write_probe`
+/// claims the instance name with an rrtype-ANY probe and §9 renames a duplicate,
+/// whereas a host name is never probed and may legitimately be shared. Where the
+/// two names COINCIDE the instance NSEC IS a host NSEC, and its bitmap names the
+/// address records this record set puts at that name — read
+/// [`emitted_nsec_types`] for what that bitmap can and cannot vouch for.
+///
+/// Best-effort: it rides the Additional section, so if it does not fit the
+/// remaining buffer the builder is rolled back to before it and the positive
+/// answers already written are sent unchanged — adding the record must never
+/// turn a deliverable response into a dropped one.
 ///
 /// Returns whether the NSEC actually made it into the message. The rollback is
-/// why that answer must be reported rather than assumed: exposure tracking asks
-/// "did this record reach the wire", and a rolled-back hint did not. See
+/// why that answer must be REPORTED rather than assumed: exposure tracking asks
+/// "did this record reach the wire", and a rolled-back record did not. See
 /// [`EmittedRecords::nsec`].
 fn push_service_nsec<const COMP_N: usize>(
   b: &mut MessageBuilder<'_, COMP_N>,
   records: &ServiceRecords,
 ) -> bool {
+  let types = emitted_nsec_types(records);
   let checkpoint = b.checkpoint();
   if b
-    .push_nsec_additional(
-      records.instance(),
-      records.ttl_secs(),
-      &INSTANCE_NSEC_TYPES,
-      true,
-    )
+    .push_nsec_additional(records.instance(), records.ttl_secs(), &types, true)
     .is_err()
   {
     b.restore(checkpoint);
@@ -233,15 +226,100 @@ fn push_service_nsec<const COMP_N: usize>(
   true
 }
 
-/// The exact RRset an instance NSEC asserts, in ONE place because two sides
-/// read it: [`push_service_nsec`] encodes it onto the wire, and
-/// [`our_nsec_identities`] reconstructs the same bytes to recognise our own NSEC
-/// coming back. A peer that publishes a byte-identical instance —
-/// a proxy or a fault-tolerance twin, the case RFC 6762 §9 names — sends this
-/// record too, and "identical rdata is never a conflict" has to cover it or a
-/// twin's NSEC alone renames us.
+/// The types a service instance name owns IN ITS OWN RIGHT: `{SRV, TXT}`
+/// (RFC 6763 §4).
+///
+/// The SEED of [`instance_rrset_types`], and only that. An instance name does
+/// not always hold just these two, so nothing may treat this constant as the
+/// answer to "what is at that name" — ask [`instance_rrset_types`] for what this
+/// record set puts there, and [`emitted_nsec_types`] for how far that may be
+/// asserted.
 pub(crate) const INSTANCE_NSEC_TYPES: [u16; 2] =
   [ResourceType::Srv.to_u16(), ResourceType::Txt.to_u16()];
+
+/// Every RRTYPE THIS RECORD SET puts at its INSTANCE name — this record set's
+/// view of that name, which is not the same thing as the name's contents; see
+/// [`emitted_nsec_types`] for the limits of what it may be used to assert.
+///
+/// [`INSTANCE_NSEC_TYPES`] — plus A and/or AAAA when the HOST name IS the
+/// instance name and the corresponding address slice is non-empty, because then
+/// [`write_announce`] emits those address records at this very name (it writes
+/// them at `records.host()`, and the two names are one).
+///
+/// ONE home for that union, because two sides read it and they used to keep a
+/// copy each: emission reaches it through [`emitted_nsec_types`] and recognition
+/// through [`our_nsec_identities`]. While they were separate, the emitted NSEC
+/// asserted `{SRV, TXT}` at a name the same datagram was putting addresses at —
+/// a §6.1 negative answer denying records its own announcement carried.
+fn instance_rrset_types(records: &ServiceRecords) -> std::vec::Vec<u16> {
+  let mut types: std::vec::Vec<u16> = INSTANCE_NSEC_TYPES.to_vec();
+  if records.instance().same_owner(records.host()) {
+    if !records.a_addrs_slice().is_empty() {
+      types.push(ResourceType::A.to_u16());
+    }
+    if !records.aaaa_addrs_slice().is_empty() {
+      types.push(ResourceType::AAAA.to_u16());
+    }
+  }
+  types
+}
+
+/// The RFC 6762 §6.1 type bitmap this crate asserts at `records`' instance name:
+/// [`instance_rrset_types`], every time.
+///
+/// # What one record set can vouch for, and what it cannot
+///
+/// The bitmap is what THIS RECORD SET publishes at that name, and that is the
+/// whole of its warrant. It is NOT a statement that the name holds nothing else
+/// on the link, because a `ServiceRecords` cannot see another route's records
+/// and the endpoint admits routes that can publish at this very name:
+///
+/// * a sibling sharing the HOST name, which `Endpoint::host_addresses_disagree`
+///   admits whenever the two publish disjoint address families — where that host
+///   name is also this instance name, the sibling's family is denied here
+///   (#147);
+/// * a route whose HOST name is this INSTANCE name: registration compares
+///   instance names to instance names and host names to host names, and never
+///   across the two roles (#147);
+/// * a PTR record at an instance name, which this bitmap never names — the
+///   DNS-SD meta PTR, or another route's service-type or subtype name (#145);
+/// * an NSEC outliving the owner that emitted it (#146).
+///
+/// What this bitmap DOES buy is the filed defect and only it: the §6.1 negative
+/// answer no longer denies records the SAME record set publishes at that name. A
+/// fixed `{SRV, TXT}` denied the A and AAAA records sitting in its own datagram
+/// every time the host name was the instance name — cache-flush bit set, so a
+/// querier stopped asking for addresses it had just been handed. The cross-route
+/// cases above are left to the endpoint-wide owner state the proto layer is not
+/// handed; #144 through #147 all wait on it. A reader must not take this bitmap
+/// as authoritative for the whole link.
+///
+/// # Why the answer is not to withhold the record
+///
+/// Because withholding removes a real negative response rather than a
+/// decoration. `endpoint::route` matches a question against a route's own unique
+/// names and, with answering enabled, routes it on THE NAME ALONE — there is no
+/// qtype filter. A query for an ABSENT type at an owned name therefore reaches
+/// the service, [`write_announce_filtered`] answers it with the record set, and
+/// the NSEC riding along is the only thing that tells the querier the type it
+/// asked for is not there. §6.1 asks a responder to *"respond asserting the
+/// nonexistence of that record using a DNS NSEC record"* and says nothing about
+/// which section carries it.
+///
+/// Withholding does not reach the residuals it would be traded for, either. They
+/// turn on what a SECOND route publishes, and
+/// `records.instance().same_owner(records.host())` — the only test one record
+/// set can run — cannot see one: the route whose HOST name is our INSTANCE name
+/// is invisible to that test, at a name this encoder writes at either way. So
+/// withholding suppresses accurate negatives where nothing is shared, and leaves
+/// the cross-route false negatives standing.
+///
+/// Of the two bitmaps available at a shared name, this is also the narrower
+/// denial: `{SRV, TXT, A}` denies one address family where `{SRV, TXT}` denied
+/// both.
+pub(crate) fn emitted_nsec_types(records: &ServiceRecords) -> std::vec::Vec<u16> {
+  instance_rrset_types(records)
+}
 
 /// The RFC 4034 §4.1.2 type-bitmap bytes for `present_types`, appended to `out`.
 ///
@@ -281,7 +359,7 @@ fn write_nsec_type_bitmap(present_types: &[u16], out: &mut std::vec::Vec<u8>) {
 /// for a peer's record: `next_name` — the owner name itself (§6.1) — in
 /// case-folded wire form, then the RFC 4034 §4.1.2 type bitmap.
 ///
-/// # Why a SET, when we emit exactly one
+/// # Why a SET, when we emit at most one
 ///
 /// RFC 6762 §9's "resource records with identical rdata are never considered
 /// inconsistent" exists for "proxies and other fault-tolerance mechanisms",
@@ -292,35 +370,27 @@ fn write_nsec_type_bitmap(present_types: &[u16], out: &mut std::vec::Vec<u8>) {
 /// They differ in exactly one configuration. When the host name IS the instance
 /// name, this service publishes its A/AAAA records at the instance name too (see
 /// `write_probe` and `proposal::our_proposal`, which counts them for the same
-/// reason), so the complete RRset at that name is `{SRV, TXT, A, AAAA}` and a
-/// conforming responder's NSEC says so. Ours says `{SRV, TXT}` — a false
-/// negative, denying address records we ourselves emit. That defect is in NSEC
-/// GENERATION, it predates this branch, and it is filed against `main` rather
-/// than patched here; fixing it changes what goes on the wire for every
-/// same-name deployment and belongs in its own change.
+/// reason), so [`instance_rrset_types`] is wider than `{SRV, TXT}` there — and
+/// the wider set is the one [`push_service_nsec`] writes.
 ///
-/// Its consequence on the CONFLICT side does not get to wait, because it is a
-/// rename: without the second form, a correct twin's correct bitmap reads as
-/// inconsistent rdata at a name we are probing, which is an RFC 6762 §8.1
-/// defeat. So this recognises both what we emit and what a conforming responder
-/// emits, and the two coincide — one entry — in every configuration where the
-/// host is a separate name.
+/// RECOGNITION MAY NOT FOLLOW EMISSION. An NSEC arriving at a name we are
+/// probing is adjudicated whether or not we would have written that exact
+/// bitmap, so both spellings must read as identical rdata — otherwise a twin's
+/// record is inconsistent rdata at a name we are probing, which is an RFC 6762
+/// §8.1 defeat. Both are kept for that reason: the bare `{SRV, TXT}` is what a
+/// twin treating the name as an ordinary instance name sends, the wider set is
+/// what one that notices the addresses sends, and neither is a conflict. The two
+/// coincide — one entry — in every configuration where the host is a separate
+/// name.
+///
+/// LENIENCE IS THE SAFE DIRECTION HERE, and the opposite of what HISTORY may
+/// claim about the same rrtype: see [`transmitted_rdata_forms`].
 pub(crate) fn our_nsec_identities(records: &ServiceRecords) -> std::vec::Vec<std::vec::Vec<u8>> {
   let mut forms = std::vec::Vec::new();
-  forms.push(emitted_nsec_identity(records));
-
-  if records.instance().same_owner(records.host()) {
-    let mut conforming: std::vec::Vec<u16> = INSTANCE_NSEC_TYPES.to_vec();
-    if !records.a_addrs_slice().is_empty() {
-      conforming.push(ResourceType::A.to_u16());
-    }
-    if !records.aaaa_addrs_slice().is_empty() {
-      conforming.push(ResourceType::AAAA.to_u16());
-    }
-    let conforming = nsec_identity(records, &conforming);
-    if !forms.contains(&conforming) {
-      forms.push(conforming);
-    }
+  forms.push(nsec_identity(records, &INSTANCE_NSEC_TYPES));
+  let published = nsec_identity(records, &instance_rrset_types(records));
+  if !forms.contains(&published) {
+    forms.push(published);
   }
   forms
 }
@@ -338,12 +408,14 @@ fn nsec_identity(records: &ServiceRecords, types: &[u16]) -> std::vec::Vec<u8> {
 /// form [`push_service_nsec`] writes, and the only NSEC bytes any echo of ours
 /// can carry.
 ///
-/// It is the first entry of [`our_nsec_identities`] BY CONSTRUCTION rather than
-/// by coincidence, which is the whole point of naming it: the two callers want
-/// opposite things from that list and only one of them may have the whole of it.
-/// See [`transmitted_rdata_forms`].
+/// It agrees with the encoder BY CONSTRUCTION rather than by coincidence, which
+/// is the whole point of naming it: both read [`emitted_nsec_types`], so neither
+/// can drift from the bitmap the other means. It is also an entry of
+/// [`our_nsec_identities`] — the two callers want opposite things from that list
+/// and only one of them may have the whole of it. See
+/// [`transmitted_rdata_forms`].
 pub(crate) fn emitted_nsec_identity(records: &ServiceRecords) -> std::vec::Vec<u8> {
-  nsec_identity(records, &INSTANCE_NSEC_TYPES)
+  nsec_identity(records, &emitted_nsec_types(records))
 }
 
 /// The canonical rdata forms `records` ACTUALLY TRANSMITS at its instance name
@@ -371,8 +443,10 @@ pub(crate) fn emitted_nsec_identity(records: &ServiceRecords) -> std::vec::Vec<u
 /// SRV and TXT DELEGATE, because each yields exactly one form there and that
 /// form IS the encoded one — `push_srv_answer` and `push_txt_answer` write the
 /// same bytes [`canonical_rdata_forms`] builds, which is what makes the §8.2
-/// byte-symmetry invariant hold. NSEC is the one rtype whose classifier list is
-/// strictly wider than what the encoder emits.
+/// byte-symmetry invariant hold. NSEC is the one rtype whose classifier list can
+/// be WIDER than what the encoder emits: where the instance name is also the
+/// host name it also accepts a twin's bare `{SRV, TXT}` spelling, which this
+/// crate does not write there, so history keeps the emitted bitmap alone.
 ///
 /// A type absent from every arm yields NOTHING, and that is the direction to
 /// fail in: retaining too little re-opens a stale echo for the identities
@@ -788,7 +862,7 @@ pub(crate) struct EmittedRecords {
   /// Tracked rather than derived, because the three encoders differ: an
   /// announcement always carries it, a §7.1-filtered response carries it only
   /// when some positive answer survived, a §6.7 legacy unicast reply never
-  /// carries it — and [`push_service_nsec`] can roll it back when the buffer is
+  /// carries it — and [`push_service_nsec`] rolls it back when the buffer is
   /// full. It is not a goodbye-able record (a §10.1 goodbye emits no NSEC), so
   /// it is deliberately outside [`Self::is_empty`] and
   /// `GoodbyeOwnership::any_instance`; what reads it is the endpoint's

--- a/mdns-proto/src/service/respond.rs
+++ b/mdns-proto/src/service/respond.rs
@@ -557,6 +557,57 @@ pub(crate) const fn transmitted_envelope(
   }
 }
 
+/// WHICH OF OUR OWNER NAMES a record of `rtype` sits at, or `None` for a type
+/// these encoders never write.
+///
+/// The ONE statement of the record-to-owner rule, and it lives beside the
+/// encoders because they are what make it true: [`write_announce`] and
+/// [`write_announce_filtered`] push the service-type PTR at
+/// `records.service_type()`, the SRV and TXT at `records.instance()`, every
+/// A / AAAA at `records.host()`, and [`push_service_nsec`] the §6.1 NSEC at
+/// `records.instance()`. `the_owner_name_rule_is_the_one_the_encoders_write_at`
+/// walks a real message and puts every record it emits to this answer, so an
+/// encoder that moves a record to another owner fails a test rather than
+/// silently splitting the rule in two.
+///
+/// # Both halves of §7.1 known-answer suppression read it
+///
+/// RFC 6762 §7.1 identifies an RRset by (name, type, class, rdata), so a
+/// known-answer may suppress one of our records only when it names the very
+/// owner that record sits at. A same-rtype, same-rdata answer under a DIFFERENT
+/// owner name is a DIFFERENT RRset and must not silence us — otherwise a
+/// querier could quiet our `host.local A x` by sending `_svc._tcp.local A x`.
+///
+/// Ingest binds a hint by asking this for the ARRIVING record's rtype and
+/// requiring that record's name to match; the emit-side filter then needs no
+/// owner test of its own, because a stored hint of the same rtype is by
+/// construction a hint at the same owner name. The two used to answer the
+/// question separately — ingest by walking our names in a precedence order,
+/// emission by matching on rtype — and where a service's instance name IS its
+/// host name they disagreed: an inbound A known-answer took the instance arm
+/// because that name matched first, while the A candidate was owned by the host,
+/// so `hint.owner == owner` could never hold and §7.1 suppression for host
+/// addresses silently never fired.
+///
+/// # What is deliberately outside it
+///
+/// The RFC 6763 §7.1 SUBTYPE PTRs, which [`write_announce_filtered`] does not
+/// KAS-filter: no candidate is ever offered under a `_sub` name, so a
+/// known-answer at one has nothing to suppress and this answers for the
+/// service-type PTR alone. And a type these encoders do not write at all, which
+/// gets `None` — the direction that can only fail to suppress.
+pub(crate) fn emitted_owner_name(
+  records: &ServiceRecords,
+  rtype: ResourceType,
+) -> Option<&crate::Name> {
+  match rtype {
+    ResourceType::Ptr => Some(records.service_type()),
+    ResourceType::Srv | ResourceType::Txt | ResourceType::Nsec => Some(records.instance()),
+    ResourceType::A | ResourceType::AAAA => Some(records.host()),
+    _ => None,
+  }
+}
+
 /// Write an unsolicited announcement: SRV, TXT, A, AAAA records.
 ///
 /// Returns the encoded length and whether the RFC 6762 §6.1 instance NSEC rode

--- a/mdns-proto/src/service/respond/tests.rs
+++ b/mdns-proto/src/service/respond/tests.rs
@@ -544,8 +544,7 @@ fn instance_rtype_exposure_mirrors_the_canonical_forms() {
 /// transmitted form, or that type silently drops out of both retention tiers.
 #[test]
 fn transmitted_forms_never_widen_the_canonical_ones() {
-  let recs = same_name_records();
-  for rtype in [
+  let rtypes = [
     ResourceType::A,
     ResourceType::AAAA,
     ResourceType::Ptr,
@@ -556,32 +555,50 @@ fn transmitted_forms_never_widen_the_canonical_ones() {
     ResourceType::Cname,
     ResourceType::Any,
     ResourceType::Unknown(0xBEEF),
-  ] {
-    let live = super::canonical_rdata_forms(&recs, rtype);
-    let transmitted = super::transmitted_rdata_forms(&recs, rtype);
-    assert!(
-      transmitted.iter().all(|f| live.contains(f)),
-      "{rtype}: history claims a form the live classifier does not even accept; \
-       transmitted {transmitted:?}, live {live:?}"
-    );
+  ];
+  for recs in [dual_stack_records(), same_name_records()] {
+    for rtype in rtypes {
+      let live = super::canonical_rdata_forms(&recs, rtype);
+      let transmitted = super::transmitted_rdata_forms(&recs, rtype);
+      assert!(
+        transmitted.iter().all(|f| live.contains(f)),
+        "{rtype}: history claims a form the live classifier does not even accept; \
+         transmitted {transmitted:?}, live {live:?}"
+      );
+      assert_eq!(
+        !transmitted.is_empty(),
+        super::INSTANCE_CANONICAL_RTYPES.contains(&rtype),
+        "{rtype}: the stated domain of the instance-rdata rule disagrees with \
+         what history can name a transmitted form for"
+      );
+    }
+  }
+  // With a host name of its own there is no second spelling for any type, so the
+  // two lists coincide.
+  let separate_host = dual_stack_records();
+  for rtype in rtypes {
     assert_eq!(
-      !transmitted.is_empty(),
-      super::INSTANCE_CANONICAL_RTYPES.contains(&rtype),
-      "{rtype}: the stated domain of the instance-rdata rule disagrees with what \
-       history can name a transmitted form for"
+      super::transmitted_rdata_forms(&separate_host, rtype),
+      super::canonical_rdata_forms(&separate_host, rtype),
+      "{rtype}: with a host name of its own there is no conforming second \
+       spelling, so the two lists coincide"
     );
   }
-  // The point of the pair: at THIS record set the two lists differ, and they
-  // differ for exactly one type.
+  // The point of the pair: at an instance name that is ALSO the host name the
+  // two lists differ, and they differ for exactly one type. The live classifier
+  // keeps accepting a §9 twin's bare `{SRV, TXT}` — a twin that spells the same
+  // claim more narrowly is not a conflict — while history keeps the one bitmap
+  // the encoder actually wrote there.
+  let same_name = same_name_records();
   assert_eq!(
-    super::canonical_rdata_forms(&recs, ResourceType::Nsec).len(),
+    super::canonical_rdata_forms(&same_name, ResourceType::Nsec).len(),
     2,
-    "an instance name that is also the host name is where the conforming twin's \
+    "an instance name that is also the host name is where the twin's narrower \
      bitmap is a second accepted form"
   );
   assert_eq!(
-    super::transmitted_rdata_forms(&recs, ResourceType::Nsec),
-    std::vec![super::emitted_nsec_identity(&recs)],
+    super::transmitted_rdata_forms(&same_name, ResourceType::Nsec),
+    std::vec![super::emitted_nsec_identity(&same_name)],
     "history keeps the encoder's bitmap and nothing else"
   );
 }
@@ -592,29 +609,26 @@ fn transmitted_forms_never_widen_the_canonical_ones() {
 /// never sent, or stop answering for one it did.
 #[test]
 fn the_emitted_nsec_identity_is_the_bitmap_the_encoder_writes() {
-  let recs = same_name_records();
-  let mut msg = [0u8; 512];
-  let mut b =
-    crate::wire::MessageBuilder::<'_, 32>::try_new(&mut msg, crate::wire::Header::new()).unwrap();
-  assert!(
-    super::push_service_nsec(&mut b, &recs),
-    "the NSEC must fit a 512-byte buffer"
-  );
-  let n = b.finish().unwrap();
-  let reader = crate::wire::MessageReader::try_parse(&msg[..n]).unwrap();
-  let rec = reader.additional().flatten().next().unwrap();
-  let on_the_wire = rec.canonical_rdata_folded().unwrap();
-  assert_eq!(
-    super::emitted_nsec_identity(&recs).as_slice(),
-    &*on_the_wire,
-    "the identity history retains must be byte-identical to what the encoder put \
-     on the wire"
-  );
+  for recs in [
+    dual_stack_records(),
+    same_name_records(),
+    same_name_v4_only_records(),
+  ] {
+    let (wrote, on_the_wire) = encode_service_nsec(&recs);
+    assert!(wrote, "the NSEC must fit a 512-byte buffer");
+    assert_eq!(
+      on_the_wire,
+      std::vec![super::emitted_nsec_identity(&recs)],
+      "the identity history retains must be byte-identical to what the encoder \
+       put on the wire"
+    );
+  }
 }
 
 /// A record set whose INSTANCE name IS its HOST name, with both address
 /// families — the configuration in which `our_nsec_identities` names a second,
-/// CONFORMING bitmap that this crate's encoder never writes.
+/// narrower bitmap (a §9 twin's bare `{SRV, TXT}`) that this crate's encoder
+/// does not write there.
 fn same_name_records() -> crate::records::ServiceRecords {
   use core::net::{Ipv4Addr, Ipv6Addr};
   let name = crate::Name::try_from_str("MyPrinter._ipp._tcp.local.").unwrap();
@@ -1006,5 +1020,239 @@ fn the_envelope_is_the_one_the_encoders_actually_write() {
   assert!(
     proposed >= 4,
     "the probe proposes SRV, TXT and both addresses; saw {proposed}"
+  );
+}
+
+// ── RFC 6762 §6.1: what we EMIT and what we RECOGNISE are one fact ──
+
+/// A record set whose INSTANCE name IS its HOST name with only ONE address
+/// family — the shape that shows the bitmap tracks what this record set
+/// actually publishes, and the shape whose residual `respond::emitted_nsec_types`
+/// states: a sibling may legally publish the OTHER family at that very name
+/// (`Endpoint::host_addresses_disagree` compares per rrtype precisely so that
+/// pair stays legal), and this bitmap cannot see it.
+fn same_name_v4_only_records() -> crate::records::ServiceRecords {
+  use core::net::Ipv4Addr;
+  let name = crate::Name::try_from_str("MyPrinter._ipp._tcp.local.").unwrap();
+  let mut r = crate::records::ServiceRecords::new(
+    crate::Name::try_from_str("_ipp._tcp.local.").unwrap(),
+    name.clone(),
+    name,
+    631,
+    120,
+  );
+  r.add_a(Ipv4Addr::new(192, 168, 1, 5));
+  r
+}
+
+/// A record's owner name, lowercased and dot-joined — an owner IDENTITY two
+/// records of one message can be compared on without caring which of them the
+/// compression table pointed at.
+fn owner_key(rec: &Ref<'_>) -> std::string::String {
+  let mut out = std::string::String::new();
+  for label in rec.name().labels() {
+    let label = label.unwrap();
+    out.push_str(&std::string::String::from_utf8_lossy(label).to_lowercase());
+    out.push('.');
+  }
+  out
+}
+
+/// The rrtypes an NSEC's RFC 4034 §4.1.2 bitmap says DO exist, read back off the
+/// wire: `next_name` in wire form (length-prefixed labels, root 0x00), then the
+/// single window block RFC 6762 §6.1 restricts mDNS to.
+fn nsec_present_types(folded: &[u8]) -> std::vec::Vec<u16> {
+  let mut i = 0usize;
+  while let Some(&len) = folded.get(i) {
+    i += 1;
+    if len == 0 {
+      break;
+    }
+    i += usize::from(len);
+  }
+  assert_eq!(
+    folded.get(i),
+    Some(&0u8),
+    "RFC 6762 §6.1 restricts mDNS NSEC to type-bitmap window block 0"
+  );
+  let blen = usize::from(*folded.get(i + 1).expect("a block length byte"));
+  let mut out = std::vec::Vec::new();
+  for (byte_idx, byte) in folded[i + 2..i + 2 + blen].iter().enumerate() {
+    for bit in 0..8u16 {
+      if byte & (0x80u8 >> bit) != 0 {
+        out.push(u16::try_from(byte_idx).unwrap() * 8 + bit);
+      }
+    }
+  }
+  out
+}
+
+/// Check every NSEC in `msg` against the message's own positive answers, and
+/// return how many NSECs it carried.
+///
+/// The property: an NSEC may not deny an rrtype that the SAME message asserts at
+/// the NSEC's own owner name. That is RFC 6762 §6.1's whole premise — the
+/// responder "can legitimately assert that no record with that name, rrtype, and
+/// rrclass exists" — read back off the datagram instead of off a constant.
+fn nsec_count_after_checking_denials(msg: &[u8]) -> usize {
+  let reader = crate::wire::MessageReader::try_parse(msg).unwrap();
+  let asserted: std::vec::Vec<(std::string::String, u16)> = reader
+    .answers()
+    .flatten()
+    .map(|rr| (owner_key(&rr), rr.rtype().to_u16()))
+    .collect();
+  let mut seen = 0usize;
+  for rr in reader.additional().flatten() {
+    if rr.rtype() != ResourceType::Nsec {
+      continue;
+    }
+    seen += 1;
+    let owner = owner_key(&rr);
+    let folded = rr.canonical_rdata_folded().unwrap();
+    let present = nsec_present_types(&folded);
+    for (answer_owner, rtype) in &asserted {
+      if *answer_owner != owner {
+        continue;
+      }
+      assert!(
+        present.contains(rtype),
+        "the §6.1 NSEC at {owner} denies rrtype {rtype}, which this very message \
+         asserts at that same owner; the bitmap lists {present:?}"
+      );
+    }
+  }
+  seen
+}
+
+/// The bytes `write_announce` produces for `records`.
+fn announce_bytes(records: &crate::records::ServiceRecords) -> std::vec::Vec<u8> {
+  let mut buf = std::vec![0u8; 1500];
+  let (n, _) = super::write_announce(records, &mut buf).unwrap();
+  buf.truncate(n);
+  buf
+}
+
+/// The bytes `write_announce_filtered` produces for `records` with no §7.1 hint
+/// suppressing anything — the other positive multicast encoder, which reaches
+/// `push_service_nsec` through its own call site.
+fn filtered_bytes(records: &crate::records::ServiceRecords) -> std::vec::Vec<u8> {
+  let mut buf = std::vec![0u8; 1500];
+  let (n, _) = super::write_announce_filtered(records, &mut buf, |_, _| false).unwrap();
+  buf.truncate(n);
+  buf
+}
+
+/// The §6.1 NSEC this crate emits must not deny records the same announcement
+/// carries.
+///
+/// Both positive multicast encoders write the A and AAAA records at
+/// `records.host()` and the NSEC at `records.instance()`. Where those two names
+/// are ONE — a supported configuration — a `{SRV, TXT}` bitmap is a
+/// cache-flushed authoritative denial of address records sitting in the very
+/// same datagram, and a querier that believes it will not ask again for the
+/// addresses it was just handed until the negative cache entry expires.
+///
+/// Asserted over the DATAGRAM, not over a bitmap constant: whatever this crate
+/// decides to emit, no NSEC may deny a type its own message asserts at that
+/// owner. The count is pinned in the same breath, because the other way to stop
+/// denying a record is to stop answering at all.
+#[test]
+fn no_emitted_nsec_denies_a_type_the_same_message_carries() {
+  // The first fixture is the CONTROL — a host name of its own, which is how this
+  // crate is overwhelmingly deployed. The other two are the defect: the instance
+  // name IS the host name, so the addresses land at the NSEC's own owner.
+  for recs in [
+    dual_stack_records(),
+    same_name_records(),
+    same_name_v4_only_records(),
+  ] {
+    for msg in [announce_bytes(&recs), filtered_bytes(&recs)] {
+      assert_eq!(
+        nsec_count_after_checking_denials(&msg),
+        1,
+        "every positive multicast response carries its §6.1 NSEC"
+      );
+    }
+  }
+}
+
+/// Run `push_service_nsec` into a fresh message; hand back whether it reported
+/// writing, and the identity bytes of every NSEC that actually reached the wire.
+fn encode_service_nsec(
+  records: &crate::records::ServiceRecords,
+) -> (bool, std::vec::Vec<std::vec::Vec<u8>>) {
+  let mut msg = [0u8; 512];
+  let mut b =
+    crate::wire::MessageBuilder::<'_, 32>::try_new(&mut msg, crate::wire::Header::new()).unwrap();
+  let wrote = super::push_service_nsec(&mut b, records);
+  let n = b.finish().unwrap();
+  let reader = crate::wire::MessageReader::try_parse(&msg[..n]).unwrap();
+  let forms = reader
+    .additional()
+    .flatten()
+    .map(|rr| rr.canonical_rdata_folded().unwrap().to_vec())
+    .collect();
+  (wrote, forms)
+}
+
+/// The EMITTED identity and the LOCALLY RECOGNISED identities are two readings
+/// of ONE fact, and the defect was that each kept its own copy of it. Pinned
+/// against the FUNCTIONS rather than against a literal bitmap, so the two cannot
+/// drift apart again.
+///
+/// They are not EQUAL, and must not be: recognition is lenient where emission is
+/// exact, so `our_nsec_identities` also accepts a §9 twin's bare `{SRV, TXT}` at
+/// a name that holds addresses. What has to hold is that whatever the encoder
+/// puts on the wire is in that list — otherwise our own record comes back as
+/// inconsistent rdata at a name we are probing.
+#[test]
+fn whatever_the_encoder_writes_is_recognised_as_ours() {
+  for recs in [
+    dual_stack_records(),
+    same_name_records(),
+    same_name_v4_only_records(),
+  ] {
+    let recognised = super::our_nsec_identities(&recs);
+    let (wrote, on_the_wire) = encode_service_nsec(&recs);
+    assert!(wrote, "the §6.1 NSEC is written at every instance name");
+    assert_eq!(
+      on_the_wire.len(),
+      usize::from(wrote),
+      "the reported answer must be the number of NSECs that reached the wire"
+    );
+    for form in &on_the_wire {
+      assert!(
+        recognised.contains(form),
+        "the encoder wrote an NSEC the recogniser would not accept as ours: \
+         {form:?} is not among {recognised:?}"
+      );
+    }
+  }
+}
+
+/// The bitmap each shape of record set asserts, pinned by VALUE — what changed
+/// on the wire and what did not.
+#[test]
+fn the_emitted_bitmap_names_the_address_families_this_record_set_publishes() {
+  let srv = ResourceType::Srv.to_u16();
+  let txt = ResourceType::Txt.to_u16();
+  let a = ResourceType::A.to_u16();
+  let aaaa = ResourceType::AAAA.to_u16();
+  assert_eq!(
+    super::emitted_nsec_types(&dual_stack_records()),
+    std::vec![srv, txt],
+    "a host name of its own puts no address record at the instance name, so \
+     nothing changes on the wire there"
+  );
+  assert_eq!(
+    super::emitted_nsec_types(&same_name_records()),
+    std::vec![srv, txt, a, aaaa],
+    "the addresses this record set publishes at that name are named, not denied"
+  );
+  assert_eq!(
+    super::emitted_nsec_types(&same_name_v4_only_records()),
+    std::vec![srv, txt, a],
+    "and only the families it actually publishes — the bitmap describes this \
+     record set, not the name"
   );
 }

--- a/mdns-proto/src/service/respond/tests.rs
+++ b/mdns-proto/src/service/respond/tests.rs
@@ -1256,3 +1256,48 @@ fn the_emitted_bitmap_names_the_address_families_this_record_set_publishes() {
      record set, not the name"
   );
 }
+
+/// `emitted_owner_name` is the ONE statement of which of our names a record of a
+/// given rtype sits at, and THE ENCODERS ARE WHAT MAKE IT TRUE — so it is pinned
+/// against a real message rather than against a second hand-maintained list.
+/// Every record both positive multicast encoders write, in every section, must
+/// sit at the owner this rule names for its rtype.
+///
+/// An encoder that moves a record to another owner name, or adds a type the rule
+/// does not answer for, fails here rather than silently splitting §7.1's owner
+/// binding back into the two disagreeing copies it had.
+#[test]
+fn the_owner_name_rule_is_the_one_the_encoders_write_at() {
+  for recs in [dual_stack_records(), same_name_records()] {
+    for msg in [announce_bytes(&recs), filtered_bytes(&recs)] {
+      let reader = crate::wire::MessageReader::try_parse(&msg).unwrap();
+      let mut checked = 0usize;
+      for rr in reader
+        .answers()
+        .flatten()
+        .chain(reader.additional().flatten())
+      {
+        // The RFC 6763 §7.1 SUBTYPE PTRs are the documented exception: they are
+        // never offered as §7.1 candidates, so the rule does not answer for them.
+        if rr.rtype() == ResourceType::Ptr
+          && !crate::endpoint::names_match_record(recs.service_type(), &rr)
+        {
+          continue;
+        }
+        let owner = super::emitted_owner_name(&recs, rr.rtype()).unwrap_or_else(|| {
+          panic!("an encoder wrote a {} the owner rule names no owner for", rr.rtype())
+        });
+        assert!(
+          crate::endpoint::names_match_record(owner, &rr),
+          "the encoder wrote a {} at an owner name the rule does not name for it",
+          rr.rtype()
+        );
+        checked += 1;
+      }
+      assert!(
+        checked >= 4,
+        "the fixture must put several rtypes to the rule; only {checked} were checked"
+      );
+    }
+  }
+}

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -11291,6 +11291,119 @@ fn our_nsec_identities_match_what_the_builder_emits() {
   );
 }
 
+/// A QUERY FOR AN ABSENT TYPE IS ANSWERED, AND THE §6.1 NSEC IS THE ANSWER.
+///
+/// The negative response is not a decoration that only ever rides an
+/// announcement nobody asked for. `endpoint::route` matches a question against a
+/// route's own unique names and, with answering enabled, routes it ON THE NAME
+/// ALONE — there is no qtype filter — and the response cycle below queues a
+/// reply for any qtype. So a querier asking an owned name for a type that is not
+/// there reaches this responder, and the NSEC riding the reply is the only thing
+/// that tells it so. Withholding the record turns that into silence and a
+/// retransmission timeout.
+///
+/// Run at the name RFC 6762 §6.1's defect lived at — instance name IS host name,
+/// where the emitted bitmap now names the address families this record set
+/// publishes rather than denying them.
+#[test]
+fn a_query_for_an_absent_type_at_an_instance_host_name_is_answered_with_an_nsec() {
+  use crate::{
+    event::ServiceQuestion,
+    wire::{MessageReader, QuestionRef, ResourceType},
+  };
+  let name = Name::try_from_str("myprinter._ipp._tcp.local.").unwrap();
+  let mut records = ServiceRecords::new(
+    Name::try_from_str("_ipp._tcp.local.").unwrap(),
+    name.clone(),
+    name.clone(),
+    631,
+    120,
+  );
+  records.add_a(core::net::Ipv4Addr::new(192, 168, 1, 10));
+  let mut svc: Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>> =
+    Service::try_new(
+      ServiceHandle::from_raw(0),
+      records,
+      FakeInstant::zero(),
+      [0u8; 32],
+      true,  // probe
+      false, // re-announce
+    );
+
+  let mut buf = std::vec![0u8; 4096];
+  let mut now = FakeInstant::zero();
+  for _ in 0..30 {
+    now = now.advance(500);
+    svc.handle_timeout(now).unwrap();
+    while let Ok(Some(_)) = svc.poll_transmit(now, &mut buf) {
+      svc.note_delivery(now, TransmitDelivery::ALL);
+    }
+    if svc.state() == ServiceState::Established {
+      break;
+    }
+  }
+  assert_eq!(
+    svc.state(),
+    ServiceState::Established,
+    "the fixture must reach the state that answers questions"
+  );
+  now = now.advance(500);
+  svc.handle_timeout(now).unwrap();
+  assert!(
+    svc.poll_transmit(now, &mut buf).unwrap().is_none(),
+    "the fixture must be silent before the question, or the NSEC found below \
+     could be an announcement's rather than the reply's"
+  );
+
+  // HINFO at the instance name: a type this responder holds no record of, and
+  // one no encoder here ever writes.
+  let mut qbuf: std::vec::Vec<u8> = std::vec::Vec::new();
+  for label in name.as_str().trim_end_matches('.').split('.') {
+    qbuf.push(u8::try_from(label.len()).unwrap());
+    qbuf.extend_from_slice(label.as_bytes());
+  }
+  qbuf.push(0u8);
+  qbuf.extend_from_slice(&ResourceType::Hinfo.to_u16().to_be_bytes());
+  qbuf.extend_from_slice(&1u16.to_be_bytes()); // QCLASS IN
+  let (qref, _) = QuestionRef::try_parse(&qbuf, 0).unwrap();
+  let src: core::net::SocketAddr = "192.0.2.7:5353".parse().unwrap();
+  svc.handle_event(
+    ServiceEvent::Question(ServiceQuestion::new(qref, src, 0)),
+    now,
+  );
+  now = now.advance(200);
+  svc.handle_timeout(now).unwrap();
+  let tx = svc
+    .poll_transmit(now, &mut buf)
+    .unwrap()
+    .expect("a question at an owned name is answered whatever its qtype");
+  let reader = MessageReader::try_parse(buf.get(..tx.size()).unwrap()).unwrap();
+
+  let nsec = reader
+    .additional()
+    .flatten()
+    .find(|rr| rr.rtype() == ResourceType::Nsec)
+    .expect("the §6.1 negative answer must ride the reply");
+  assert_eq!(
+    &*nsec.canonical_rdata_folded().unwrap(),
+    respond::emitted_nsec_identity(svc.records()).as_slice(),
+    "the negative answer must be the bitmap this record set publishes at that \
+     name"
+  );
+  assert!(
+    respond::emitted_nsec_types(svc.records()).contains(&ResourceType::A.to_u16()),
+    "the reply carries an A record at this very name, so the bitmap riding \
+     beside it must name A rather than deny it"
+  );
+  assert!(
+    reader
+      .answers()
+      .flatten()
+      .any(|rr| rr.rtype() == ResourceType::A),
+    "the same datagram really does assert the A record the bitmap names"
+  );
+}
+
 // ── the reader property the fold relies on ──
 
 /// The reader property the fold depends on, pinned rather than asserted in a

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -4540,6 +4540,125 @@ fn kas_wrong_owner_known_answer_does_not_suppress() {
   );
 }
 
+/// A known-answer that has EXPIRED by the instant `poll_transmit` is given must
+/// not suppress, even though no `handle_timeout` or `handle_event` ran between
+/// the queueing of the response and the poll.
+///
+/// The hint's licence to suppress is the querier still holding the record, and
+/// that licence ends on the caller's clock — which `poll_transmit` receives as
+/// a parameter. Judging it against the last instant some OTHER method happened
+/// to carry lets a permitted Sans-I/O call order (question → `handle_timeout` →
+/// wait → `poll_transmit`) keep a long-dead hint alive: the querier's cache
+/// entry is gone, nobody else on the link will send our record, and RFC 6762
+/// §7.1 licenses no suppression there.
+///
+/// Run at BOTH name coincidences, because that is where an A hint became
+/// storable at all: while the emit side classified a candidate by rtype and
+/// ingest classified an arriving record by walking our names in order, an A at
+/// a name that is also the instance name or the service type bound to the wrong
+/// owner and could never match. Both now bind by rtype, so both reach this
+/// filter.
+#[test]
+fn an_expired_known_answer_does_not_suppress_at_polls_own_clock() {
+  use crate::{
+    event::ServiceQuestion,
+    wire::{MessageReader, QuestionRef, ResourceType},
+  };
+
+  /// Is the A record missing from the response? `host` is the name it sits at —
+  /// one of the two coincidences.
+  fn suppressed_after_expiry(host: &str) -> bool {
+    let our_ttl: u32 = 120;
+    let mut records = ServiceRecords::new(
+      Name::try_from_str("_ipp._tcp.local.").unwrap(),
+      Name::try_from_str("myprinter._ipp._tcp.local.").unwrap(),
+      Name::try_from_str(host).unwrap(),
+      631,
+      our_ttl,
+    );
+    records.add_a(core::net::Ipv4Addr::new(192, 168, 1, 10));
+    let mut svc: Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>> =
+      Service::try_new(
+        ServiceHandle::from_raw(0),
+        records,
+        FakeInstant::zero(),
+        [0u8; 32],
+        true,
+        true,
+      );
+    let now = drive_to_established(&mut svc);
+    inject_question_to_set_response_deadline(&mut svc, now);
+
+    // A known-answer for our A record at exactly the §7.1 half-TTL threshold,
+    // so it is stored and expires 60 s after `now`.
+    let mut a_buf: std::vec::Vec<u8> = std::vec::Vec::new();
+    make_a_record_ref(&mut a_buf, host, our_ttl / 2, [192, 168, 1, 10]);
+    let (a_ref, _) = Ref::try_parse(&a_buf, 0).unwrap();
+    svc.handle_event(
+      ServiceEvent::KnownAnswer(KnownAnswer::new("0.0.0.0:5353".parse().unwrap(), a_ref)),
+      now,
+    );
+    assert!(
+      svc
+        .kas_hints
+        .iter()
+        .any(|s| s.map(|h| h.rtype == ResourceType::A).unwrap_or(false)),
+      "the A known-answer must be stored as a hint at host `{host}`"
+    );
+
+    // The question that pulls the A onto the wire, then the jitter window
+    // closes and the response is queued.
+    let mut qbuf: std::vec::Vec<u8> = std::vec::Vec::new();
+    for label in "myprinter._ipp._tcp.local."
+      .trim_end_matches('.')
+      .split('.')
+    {
+      qbuf.push(label.len() as u8);
+      qbuf.extend_from_slice(label.as_bytes());
+    }
+    qbuf.push(0u8);
+    qbuf.extend_from_slice(&255u16.to_be_bytes()); // QTYPE ANY
+    qbuf.extend_from_slice(&1u16.to_be_bytes()); // QCLASS IN
+    let (qref, _) = QuestionRef::try_parse(&qbuf, 0).unwrap();
+    let src: core::net::SocketAddr = "0.0.0.0:5353".parse().unwrap();
+    svc.handle_event(
+      ServiceEvent::Question(ServiceQuestion::new(qref, src, 0)),
+      now,
+    );
+    let queued = now.advance(200);
+    svc.handle_timeout(queued).unwrap();
+    assert_eq!(
+      svc.pending_transmits[0],
+      Some(PendingTransmitKind::Response),
+      "a Response must be queued at host `{host}`"
+    );
+
+    // ONLY the clock handed to `poll_transmit` moves past the hint's expiry —
+    // no further event or timeout, which is what a Sans-I/O caller is allowed
+    // to do and what leaves any cached instant behind.
+    let polled = queued.advance(61_000);
+    let mut out = std::vec![0u8; 4096];
+    let transmit = svc
+      .poll_transmit(polled, &mut out)
+      .unwrap()
+      .expect("the queued response must still be emitted");
+    let reader = MessageReader::try_parse(&out[..transmit.size()]).unwrap();
+    !reader.answers().any(|rr| {
+      rr.map(|rec| rec.rtype() == ResourceType::A)
+        .unwrap_or(false)
+    })
+  }
+
+  assert!(
+    !suppressed_after_expiry("myprinter._ipp._tcp.local."),
+    "instance == host: an expired known-answer must not suppress the A record"
+  );
+  assert!(
+    !suppressed_after_expiry("_ipp._tcp.local."),
+    "service type == host: an expired known-answer must not suppress the A record"
+  );
+}
+
 // ── same-tick response + lifecycle both fire ──────────────────
 
 /// When both response_deadline and lifecycle_deadline are due at the same

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -1797,12 +1797,24 @@ fn truncated_meta_query_delays_reply_to_400_500ms() {
   );
 }
 
+/// [`meta_reply_fires_at`] with the reply polled on the same instant the
+/// jittered deadline is fired, which is the ordinary driver shape.
+fn meta_reply_fires(with_ka: bool, ka_from_questioner: bool, ka_ttl: u32) -> bool {
+  meta_reply_fires_at(with_ka, ka_from_questioner, ka_ttl, 200)
+}
+
 /// Drive to Established, deliver a §9 meta-query from a 5353 source, optionally
 /// deliver a meta known-answer (PTR owned by the DNS-SD meta name, target =
-/// our service type) with the given TTL and source, then fire the jittered
-/// deadline. Returns whether a meta-PTR reply was emitted (the only thing
-/// `poll_transmit` can produce in this window — so `false` means suppressed).
-fn meta_reply_fires(with_ka: bool, ka_from_questioner: bool, ka_ttl: u32) -> bool {
+/// our service type) with the given TTL and source, fire the jittered deadline
+/// at 200 ms, then poll `poll_after_ms` after the meta-query arrived. Returns
+/// whether a meta-PTR reply was emitted (the only thing `poll_transmit` can
+/// produce in this window — so `false` means suppressed).
+fn meta_reply_fires_at(
+  with_ka: bool,
+  ka_from_questioner: bool,
+  ka_ttl: u32,
+  poll_after_ms: u64,
+) -> bool {
   use crate::{
     event::{KnownAnswer, ServiceQuestion},
     wire::{QuestionRef, Ref},
@@ -1866,8 +1878,39 @@ fn meta_reply_fires(with_ka: bool, ka_from_questioner: bool, ka_ttl: u32) -> boo
 
   let t = now.advance(200); // past the 20–120 ms meta jitter window
   svc.handle_timeout(t).unwrap();
+  // Only the clock handed to `poll_transmit` moves on from here — no further
+  // event or timeout, which is what a Sans-I/O caller is allowed to do.
+  let polled = now.advance(poll_after_ms);
   let mut buf = std::vec![0u8; 4096];
-  svc.poll_transmit(t, &mut buf).unwrap().is_some()
+  svc.poll_transmit(polled, &mut buf).unwrap().is_some()
+}
+
+/// A meta known-answer that has EXPIRED by the instant `poll_transmit` is given
+/// must not suppress the §9 service-type enumeration reply.
+///
+/// Same class as `an_expired_known_answer_does_not_suppress_at_polls_own_clock`,
+/// on the path that stored no deadline at all: the meta hint was a bare `bool`,
+/// so once set it suppressed on every later poll however long the caller waited.
+/// The half-TTL test at arrival says the answer is fresh ENOUGH to suppress; it
+/// does not say for how long. Over-suppression here is the worst direction in
+/// the crate — the querier gets no service-type enumeration from us, and unlike
+/// an instance record nobody else on the link advertises our type for us.
+#[test]
+fn an_expired_meta_known_answer_does_not_suppress_at_polls_own_clock() {
+  // Our TTL is 120, so a known answer at TTL 60 sits exactly on the §7.1
+  // half-TTL threshold: stored, and expiring 60 s after it arrived.
+  assert!(
+    !meta_reply_fires_at(true, true, 60, 200),
+    "control: a live meta known-answer at the half-TTL threshold must suppress"
+  );
+  assert!(
+    meta_reply_fires_at(true, true, 60, 61_000),
+    "a meta known-answer expired by poll time must NOT suppress the meta reply"
+  );
+  assert!(
+    !meta_reply_fires_at(true, true, 120, 61_000),
+    "control: a known-answer whose own TTL outlives the poll still suppresses"
+  );
 }
 
 /// (RFC 6763 §9 + §7.1): a meta questioner that already knows our

--- a/mdns-proto/src/service/tests.rs
+++ b/mdns-proto/src/service/tests.rs
@@ -4513,8 +4513,8 @@ fn kas_wrong_owner_known_answer_does_not_suppress() {
   inject_question_to_set_response_deadline(&mut svc, now);
 
   // Bogus known-answer: an A record OWNED BY THE SERVICE-TYPE name, rdata = our
-  // host's A. It is stored (its name is one of ours) but bound to owner-kind
-  // ServiceType, so it can never match the host-owned A candidate.
+  // host's A. Our A candidate sits at the HOST name, so this names a different
+  // RRset and is dropped on ingest — it can never suppress the host-owned A.
   let mut a_buf: std::vec::Vec<u8> = std::vec::Vec::new();
   make_a_record_ref(&mut a_buf, "_ipp._tcp.local.", our_ttl, [192, 168, 1, 10]);
   let (a_ref, _) = Ref::try_parse(&a_buf, 0).unwrap();
@@ -12565,5 +12565,117 @@ fn a_parked_section9_revert_is_reported_by_the_next_timeout() {
   assert!(
     matches!(svc.poll_transmit(at, &mut buf), Ok(None)),
     "and nothing goes on the wire in the meantime"
+  );
+}
+
+// ── §7.1 owner binding where the instance name IS the host name ──
+
+/// A service whose INSTANCE name IS its HOST name, with one A address — a
+/// supported configuration, and the one in which the two halves of §7.1
+/// suppression used to classify the same record differently.
+fn make_same_name_service(
+  ttl_secs: u32,
+) -> Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>> {
+  let name = Name::try_from_str(PROBED_NAME).unwrap();
+  let mut records = ServiceRecords::new(
+    Name::try_from_str("_ipp._tcp.local.").unwrap(),
+    name.clone(),
+    name,
+    631,
+    ttl_secs,
+  );
+  records.add_a(core::net::Ipv4Addr::new(192, 168, 1, 10));
+  Service::try_new(
+    ServiceHandle::from_raw(0),
+    records,
+    FakeInstant::zero(),
+    [0u8; 32],
+    true,
+    true,
+  )
+}
+
+/// Drive `svc` to Established, open a response cycle, feed it an A known-answer
+/// owned by `ka_owner` carrying `addr`, and report whether our A record survived
+/// into the §7.1-filtered response.
+fn a_record_survives_known_answer(
+  svc: &mut Service<FakeInstant, slab::Slab<Transmit>, slab::Slab<ServiceUpdate>>,
+  ka_owner: &str,
+  addr: [u8; 4],
+) -> bool {
+  use crate::wire::{MessageReader, ResourceType};
+
+  let now = drive_to_established(svc);
+  inject_question_to_set_response_deadline(svc, now);
+  let mut a_buf: std::vec::Vec<u8> = std::vec::Vec::new();
+  // TTL 120 == our TTL, comfortably over the §7.1 half-TTL threshold.
+  make_a_record_ref(&mut a_buf, ka_owner, 120, addr);
+  let (a_ref, _) = Ref::try_parse(&a_buf, 0).unwrap();
+  let ka = KnownAnswer::new("0.0.0.0:5353".parse().unwrap(), a_ref);
+  svc.handle_event(ServiceEvent::KnownAnswer(ka), now);
+
+  let now2 = now.advance(200);
+  svc.handle_timeout(now2).unwrap();
+  let mut out = std::vec![0u8; 4096];
+  let transmit = svc
+    .poll_transmit(now2, &mut out)
+    .unwrap()
+    .expect("a response must be emitted");
+  let reader = MessageReader::try_parse(&out[..transmit.size()]).unwrap();
+  reader.answers().any(|rr| {
+    rr.map(|rec| rec.rtype() == ResourceType::A)
+      .unwrap_or(false)
+  })
+}
+
+/// RFC 6762 §7.1 known-answer suppression, at a service whose instance name IS
+/// its host name.
+///
+/// The emit side owns the A candidate at `records.host()`. The ingest side used
+/// to stamp an arriving known-answer with the FIRST of our three names that
+/// matched it, and at this configuration that is the instance name — so
+/// `hint.owner == owner` could never hold, and a querier that already held our
+/// address record was sent it again on every query, at every same-name
+/// deployment.
+///
+/// The failure was to SUPPRESS, so its cost was one redundant but truthful
+/// record on a link where §7.1 is a SHOULD-level bandwidth optimisation. The
+/// opposite failure is not benign at all: suppressing a record the querier does
+/// not hold silences an answer nobody else will give. So the direction is pinned
+/// here too — a known-answer under a genuinely different owner must go on
+/// suppressing nothing, in either configuration.
+#[test]
+fn a_host_address_known_answer_suppresses_where_the_instance_name_is_the_host_name() {
+  let our_ttl: u32 = 120;
+  let ours = [192, 168, 1, 10];
+
+  // THE CONTROL — a host name of its own, which is where the two halves already
+  // agreed and where nothing about this changes.
+  let mut svc = make_service(our_ttl);
+  assert!(
+    !a_record_survives_known_answer(&mut svc, "host.local.", ours),
+    "instance != host: a known-answer at our host name names our A RRset and \
+     §7.1 must suppress it"
+  );
+
+  // THE DEFECT — one name owning the instance records and the addresses alike.
+  let mut svc = make_same_name_service(our_ttl);
+  assert!(
+    !a_record_survives_known_answer(&mut svc, PROBED_NAME, ours),
+    "instance == host: the A record sits at that one name, so a known-answer \
+     for it names our RRset and §7.1 must suppress it"
+  );
+
+  // THE DIRECTION — another owner is another RRset, and stays one.
+  let mut svc = make_same_name_service(our_ttl);
+  assert!(
+    a_record_survives_known_answer(&mut svc, "someone-else.local.", ours),
+    "a known-answer under an owner that is none of ours must suppress nothing"
+  );
+  let mut svc = make_service(our_ttl);
+  assert!(
+    a_record_survives_known_answer(&mut svc, PROBED_NAME, ours),
+    "instance != host: our A sits at the HOST name, so a same-rdata answer at \
+     the INSTANCE name is a different RRset and must not suppress it"
   );
 }


### PR DESCRIPTION
Closes #98. Closes #123.
